### PR TITLE
Fixes typo

### DIFF
--- a/pages/debug-data.php
+++ b/pages/debug-data.php
@@ -54,7 +54,7 @@ $info = Health_Check_Debug_Data::debug_data();
 						?>
 `</textarea>
 			<p>
-				<?php esc_html_e( 'Some information may be filtered out from the list you are about to copy, this is information that may be considers private, and is not meant to be shared in a public forum.', 'health-check' ); ?>
+				<?php esc_html_e( 'Some information may be filtered out from the list you are about to copy, this is information that may be considered private, and is not meant to be shared in a public forum.', 'health-check' ); ?>
 				<br>
 				<button type="button" class="button button-primary" onclick="document.getElementById('system-information-english-copy-field').select();"><?php esc_html_e( 'Mark field for copying', 'health-check' ); ?></button>
 			</p>
@@ -93,7 +93,7 @@ $info = Health_Check_Debug_Data::debug_data();
 				?>
 `</textarea>
 			<p>
-				<?php esc_html_e( 'Some information may be filtered out from the list you are about to copy, this is information that may be considers private, and is not meant to be shared in a public forum.', 'health-check' ); ?>
+				<?php esc_html_e( 'Some information may be filtered out from the list you are about to copy, this is information that may be considered private, and is not meant to be shared in a public forum.', 'health-check' ); ?>
 				<br>
 				<button type="button" class="button button-primary" onclick="document.getElementById('system-information-copy-field').select();"><?php esc_html_e( 'Mark field for copying', 'health-check' ); ?></button>
 			</p>


### PR DESCRIPTION
Replaces ```that may be considers private```
with ```that may be considered private```.