### PR TITLE
Update Troubleshooting Mode Checkbox for 0.7.0

### DIFF
--- a/includes/class-health-check-troubleshoot.php
+++ b/includes/class-health-check-troubleshoot.php
@@ -86,7 +86,7 @@ class Health_Check_Troubleshoot {
 			if ( ! isset( $_POST['health-check-troubleshoot-mode-confirmed'] ) ) {
 				printf(
 					'<div class="notice notice-error inline"><p>%s</p></div>',
-					esc_html__( 'You did not check that you understand how to leave troubleshooter mode, please read the explanation and confirm that you understand the procedure first.', 'health-check' )
+					esc_html__( 'You did not check that you understand how to leave Troubleshooting Mode, please read the explanation and confirm that you understand the procedure first.', 'health-check' )
 				);
 			}
 			else {
@@ -114,7 +114,7 @@ class Health_Check_Troubleshoot {
 				<p>
 					<label>
 						<input type="checkbox" name="health-check-troubleshoot-mode-confirmed">
-						<?php esc_html_e( 'I understand that troubleshooter mode is active until the next time I log out', 'health-check' ); ?>
+						<?php esc_html_e( 'I understand that Troubleshooting Mode is active until I disable it', 'health-check' ); ?>
 					</label>
 
 				</p>


### PR DESCRIPTION
Health Check 0.7.0 introduced a method for disabling troubleshooting mode without needing to log out and back in again. The text of the checkbox for Troubleshooting Mode has been edited to reflect this, and the name has been made consistent with the rest of the text.