### PR TITLE
Update Troubleshooting Mode Text for 0.7.0 

### DIFF
--- a/pages/troubleshoot.php
+++ b/pages/troubleshoot.php
@@ -6,16 +6,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="notice notice-warning inline">
 	<p>
-		<?php esc_html_e( 'When troubleshooting issues on your site, you are likely to be told to disable all plugins.', 'health-check' ); ?>
+		<?php esc_html_e( 'When troubleshooting issues on your site, you are likely to be told to disable all plugins and switch to the default theme.', 'health-check' ); ?>
 		<?php esc_html_e( 'Understandably, you do not wish to do so as it may affect your site visitors, leaving them with lost functionality.', 'health-check' ); ?>
 	</p>
 
 	<p>
-		<?php esc_html_e( 'By enabling the troubleshooting mode, all plugins will appear deactivated for your current logged in session, but all other users will see your site as usual.', 'health-check' ); ?>
+		<?php esc_html_e( 'By enabling the Troubleshooting Mode, all plugins will appear deactivated and your site will switch to the default theme only for you. All other users will see your site as usual.', 'health-check' ); ?>
 	</p>
 
 	<p>
-		<?php esc_html_e( 'A Troubleshooting Mode menu is added to your admin bar, this will allow you to enable individual plugins when looking for issues.', 'health-check' ); ?>
+		<?php esc_html_e( 'A Troubleshooting Mode menu is added to your admin bar, which will allow you to enable plugins individually, switch back to your current theme, and disable Troubleshooting Mode.', 'health-check' ); ?>
 	</p>
 
 	<p>


### PR DESCRIPTION
Health Check 0.7.0 introduced a method for disabling troubleshooting mode without needing to log out and back in again and an automatic switch to the default theme. The text of the Troubleshooting page has been edited to reflect this, with a few other minor changes.