### PR TITLE
Add the `wordpressdotorg` user to the contributors list

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Health Check ===
 Tags: health check
-Contributors: westi, pento, Clorith
+Contributors: wordpressdotorg, westi, pento, Clorith
 Requires at least: 3.8
 Tested up to: 4.9
 Stable tag: 0.9.0


### PR DESCRIPTION
This change ensures the plugin shows under the `wordpressdotorg` users profile at https://profiles.wordpress.org/wordpressdotorg#content-plugins

aka. A pseudo WordPress "verfied blue tick program" for officially sanctioned plugins and themes