### PR TITLE
core update needed notice

### DIFF
--- a/src/includes/class-health-check-debug-data.php
+++ b/src/includes/class-health-check-debug-data.php
@@ -45,13 +45,25 @@ class Health_Check_Debug_Data {
 			$wp_config_path = dirname( ABSPATH ) . '/wp-config.php';
 		}
 
+		$core_current_version = get_bloginfo( 'version' );
+		$core_updates         = get_core_updates();
+
+		foreach ( $core_updates as $core => $update ) {
+			if ( 'upgrade' === $update->response ) {
+				// translators: %s: Latest WordPress version number.
+				$core_update_needed = ' ' . sprintf( __( '( Latest version: %s )', 'health-check' ), $update->version );
+			} else {
+				$core_update_needed = '';
+			}
+		}
+
 		$info = array(
 			'wp-core'             => array(
 				'label'  => __( 'WordPress', 'health-check' ),
 				'fields' => array(
 					array(
 						'label' => __( 'Version', 'health-check' ),
-						'value' => get_bloginfo( 'version' ),
+						'value' => $core_current_version . $core_update_needed,
 					),
 					array(
 						'label' => __( 'Language', 'health-check' ),


### PR DESCRIPTION
adds a Latest Version notice if there's a core update, the same way that it was added for plugins / themes.

![39165 15](https://user-images.githubusercontent.com/22611066/36939968-18a50d02-1f43-11e8-845d-750f257b2f93.png)

( fixes #79 )