### PR TITLE
Split up the tools tab

### DIFF
--- a/assets/javascript/accordion.js
+++ b/assets/javascript/accordion.js
@@ -1,0 +1,21 @@
+jQuery( document ).ready(function( $ ) {
+	$( '.health-check-accordion-trigger' ).click(function() {
+		var isExpanded = ( 'true' === $( this ).attr( 'aria-expanded' ) );
+
+		if ( isExpanded ) {
+			$( this ).attr( 'aria-expanded', 'false' );
+			$( '#' + $( this ).attr( 'aria-controls' ) ).attr( 'hidden', true );
+		} else {
+			$( this ).attr( 'aria-expanded', 'true' );
+			$( '#' + $( this ).attr( 'aria-controls' ) ).attr( 'hidden', false );
+		}
+	});
+
+	$( '.health-check-accordion' ).on( 'keyup', '.health-check-accordion-trigger', function( e ) {
+		if ( '38' === e.keyCode.toString() ) {
+			$( '.health-check-accordion-trigger', $( this ).closest( 'dt' ).prevAll( 'dt' ) ).focus();
+		} else if ( '40' === e.keyCode.toString() ) {
+			$( '.health-check-accordion-trigger', $( this ).closest( 'dt' ).nextAll( 'dt' ) ).focus();
+		}
+	});
+});

--- a/assets/sass/health-check.scss
+++ b/assets/sass/health-check.scss
@@ -35,58 +35,6 @@ body {
 			}
 		}
 
-		.file-integrity-table {
-
-			thead,
-			tbody,
-			tfoot {
-
-				th,
-				td {
-
-					&:first-child {
-
-						text-align: center;
-						width: 60px;
-					}
-				}
-			}
-		}
-
-		.tools-email-table {
-
-			border: 0;
-			box-shadow: none;
-
-			td {
-
-				&:first-child {
-					width: 280px;
-				}
-
-				@media (max-width: 768px) {
-					display: block;
-				}
-
-			}
-
-			input {
-				width: 100%;
-			}
-
-			label {
-				display: block;
-				clear: both;
-			}
-
-		}
-
-		#health-check-mail-check,
-		#health-check-file-integrity {
-
-			margin-bottom: 15px;
-		}
-
 		.pass,
 		.good {
 
@@ -134,134 +82,21 @@ body {
 			}
 		}
 
-		#health-check-diff-modal {
-
-			width: 100vw;
-			height: 100%;
-			position: fixed;
-			top: 0;
-			left: 0;
-			background: rgba(0, 0, 0, 0.7);
-			display: none;
-			z-index: 99999;
-
-			#health-check-diff-modal-content {
-
-				background: #fff;
-				height: calc(100% - 120px);
-				width: calc(100% - 120px);
-				margin-top: 40px;
-				margin-left: 40px;
-				padding: 20px;
-				display: block;
-			}
-
-			#health-check-diff-modal-diff {
-
-				width: 100%;
-				height: calc(100% - 80px);
-				overflow-y: auto;
-				display: block;
-				position: relative;
-
-				table {
-
-					&.diff {
-
-						td {
-
-							&:nth-child(2) {
-
-								background: #f3f3f3;
-							}
-						}
-					}
-				}
-			}
-		}
-
-		#health-check-diff-modal-close-ref {
-
-			position: relative;
-			display: block;
-			float: right;
-			color: #000;
-			text-decoration: none;
-		}
-
 		.spinner {
 			float: none;
 		}
 
-		.tool {
-			background: #fff;
-			margin-top: 15px;
-			padding: 15px;
+		/* Tools screen styles */
+		@import "modules/tools";
 
-			h3 {
-				margin-top: 0;
-			}
-		}
-
-		.tool-first {
-			margin-top: 5px;
-		}
+		/* Diff viewer styles */
+		@import "modules/diff-viewer";
 
 	}
 }
 
-.health-check-modal {
+/* Accordion styles */
+@import "modules/accordion";
 
-	display: none;
-	position: fixed;
-	z-index: 1000;
-	padding-top: 100px;
-	left: 0;
-	top: 0;
-	width: 100%;
-	height: 100%;
-	overflow: auto;
-	background-color: rgb(0, 0, 0);
-	background-color: rgba(0, 0, 0, 0.4);
-
-	&.show {
-
-		display: block;
-	}
-
-	.modal-content {
-
-		background-color: #fefefe;
-		margin: auto;
-		padding: 20px;
-		border: 1px solid #888;
-		width: 30%;
-
-		.modal-close {
-
-			color: #aaa;
-			float: right;
-			font-size: 28px;
-			font-weight: 600;
-			cursor: pointer;
-		}
-
-		#dynamic-content {
-
-			display: block;
-			width: 100%;
-		}
-	}
-
-	.modal-close {
-
-		&:hover,
-		&:focus {
-
-			color: #aaa;
-			float: right;
-			font-size: 28px;
-			font-weight: 600;
-		}
-	}
-}
+/* Modal styles */
+@import "modules/modal";

--- a/assets/sass/modules/_accordion.scss
+++ b/assets/sass/modules/_accordion.scss
@@ -1,0 +1,95 @@
+.health-check-accordion {
+
+	border: 1px solid hsl(0, 0%, 82%);
+	border-radius: 0.3em;
+	box-shadow: 0 1px 2px hsl(0, 0%, 82%);
+
+	> * + * {
+
+		border-top: 1px solid hsl(0, 0%, 82%);
+	}
+
+	dt {
+
+		font-weight: 600;
+
+		&:first-child {
+
+			border-radius: 0.3em 0.3em 0 0;
+		}
+	}
+
+	.health-check-accordion-trigger {
+
+		background: #fff;
+		border: 0;
+		color: hsl(0, 0%, 13%);
+		display: block;
+		font-size: 1rem;
+		font-weight: 400;
+		margin: 0;
+		padding: 1em 1.5em;
+		position: relative;
+		text-align: left;
+		width: 100%;
+
+		&:hover,
+		&:focus,
+		&:active {
+
+			background: hsl(0, 0%, 87%);
+		}
+
+		.title {
+
+			display: block;
+			pointer-events: none;
+		}
+
+		.icon {
+
+			border: solid hsl(0, 0%, 62%);
+			border-width: 0 2px 2px 0;
+			height: 0.5rem;
+			pointer-events: none;
+			position: absolute;
+			right: 1.5em;
+			top: 50%;
+			transform: translateY(-60%) rotate(45deg);
+			width: 0.5rem;
+		}
+
+		&[aria-expanded="true"] {
+
+			.icon {
+
+				transform: translateY(-50%) rotate(-135deg);
+			}
+		}
+	}
+
+	.health-check-accordion-panel {
+
+		margin: 0;
+		padding: 1em 1.5em;
+		background: #fff;
+
+		> div {
+
+			display: block;
+		}
+
+		&[hidden] {
+
+			display: none;
+		}
+	}
+
+	dl {
+
+		dd {
+
+			margin: 0 0 0.5em 2em;
+		}
+	}
+}

--- a/assets/sass/modules/_diff-viewer.scss
+++ b/assets/sass/modules/_diff-viewer.scss
@@ -1,0 +1,54 @@
+#health-check-diff-modal {
+
+	width: 100vw;
+	height: 100%;
+	position: fixed;
+	top: 0;
+	left: 0;
+	background: rgba(0, 0, 0, 0.7);
+	display: none;
+	z-index: 99999;
+
+	#health-check-diff-modal-content {
+
+		background: #fff;
+		height: calc(100% - 120px);
+		width: calc(100% - 120px);
+		margin-top: 40px;
+		margin-left: 40px;
+		padding: 20px;
+		display: block;
+	}
+
+	#health-check-diff-modal-diff {
+
+		width: 100%;
+		height: calc(100% - 80px);
+		overflow-y: auto;
+		display: block;
+		position: relative;
+
+		table {
+
+			&.diff {
+
+				td {
+
+					&:nth-child(2) {
+
+						background: #f3f3f3;
+					}
+				}
+			}
+		}
+	}
+}
+
+#health-check-diff-modal-close-ref {
+
+	position: relative;
+	display: block;
+	float: right;
+	color: #000;
+	text-decoration: none;
+}

--- a/assets/sass/modules/_modal.scss
+++ b/assets/sass/modules/_modal.scss
@@ -1,0 +1,55 @@
+.health-check-modal {
+
+	display: none;
+	position: fixed;
+	z-index: 1000;
+	padding-top: 100px;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
+	overflow: auto;
+	background-color: rgb(0, 0, 0);
+	background-color: rgba(0, 0, 0, 0.4);
+
+	&.show {
+
+		display: block;
+	}
+
+	.modal-content {
+
+		background-color: #fefefe;
+		margin: auto;
+		padding: 20px;
+		border: 1px solid #888;
+		width: 30%;
+
+		.modal-close {
+
+			color: #aaa;
+			float: right;
+			font-size: 28px;
+			font-weight: 600;
+			cursor: pointer;
+		}
+
+		#dynamic-content {
+
+			display: block;
+			width: 100%;
+		}
+	}
+
+	.modal-close {
+
+		&:hover,
+		&:focus {
+
+			color: #aaa;
+			float: right;
+			font-size: 28px;
+			font-weight: 600;
+		}
+	}
+}

--- a/assets/sass/modules/_tools.scss
+++ b/assets/sass/modules/_tools.scss
@@ -1,0 +1,51 @@
+.file-integrity-table {
+
+	thead,
+	tbody,
+	tfoot {
+
+		th,
+		td {
+
+			&:first-child {
+
+				text-align: center;
+				width: 60px;
+			}
+		}
+	}
+}
+
+.tools-email-table {
+
+	border: 0;
+	box-shadow: none;
+
+	td {
+
+		&:first-child {
+			width: 280px;
+		}
+
+		@media (max-width: 768px) {
+			display: block;
+		}
+
+	}
+
+	input {
+		width: 100%;
+	}
+
+	label {
+		display: block;
+		clear: both;
+	}
+
+}
+
+#health-check-mail-check,
+#health-check-file-integrity {
+
+	margin-bottom: 15px;
+}

--- a/src/pages/tools.php
+++ b/src/pages/tools.php
@@ -11,54 +11,75 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<div class="tool tool-first">
-	<h3><?php esc_html_e( 'File Integrity', 'health-check' ); ?></h3>
-	<div class="tool-content">
-		<p>
-			<?php _e( 'The File Integrity checks all the core files with the <code>checksums</code> provided by the WordPress API to see if they are intact. If there are changes you will be able to make a Diff between the files hosted on WordPress.org and your installation to see what has been changed.', 'health-check' ); ?>
-		</p>
-		<form action="#" id="health-check-file-integrity" method="POST">
+
+<dl id="health-check-tools" role="presentation" class="health-check-accordion">
+	<dt role="heading" aria-level="2">
+		<button aria-expanded="true" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-1" id="health-check-accordion-heading-1" type="button">
+			<span class="title">
+				<?php esc_html_e( 'File Integrity', 'health-check' ); ?>
+			</span>
+			<span class="icon"></span>
+		</button>
+	</dt>
+	<dd id="health-check-accordion-block-1" role="region" aria-labelledby="health-check-accordion-heading-1" class="health-check-accordion-panel">
+		<div>
 			<p>
-				<input type="submit" class="button button-primary" value="<?php esc_html_e( 'Check the Files Integrity', 'health-check' ); ?>">
+				<?php _e( 'The File Integrity checks all the core files with the <code>checksums</code> provided by the WordPress API to see if they are intact. If there are changes you will be able to make a Diff between the files hosted on WordPress.org and your installation to see what has been changed.', 'health-check' ); ?>
 			</p>
-		</form>
-	</div>
-	<div id="tools-file-integrity-response-holder">
-		<span class="spinner"></span>
-	</div>
-</div>
-<div class="tool">
-	<h3><?php esc_html_e( 'Mail Check', 'health-check' ); ?></h3>
-	<div class="tool-content">
-		<p>
-			<?php _e( 'The Mail Check will invoke the <code>wp_mail()</code> function and check if it succeeds. We will use the E-mail address you have set up, but you can change it below if you like.', 'health-check' ); ?>
-		</p>
-		<form action="#" id="health-check-mail-check" method="POST">
-			<table class="widefat tools-email-table">
-				<tr>
-					<td>
-						<p>
-							<?php
+			<form action="#" id="health-check-file-integrity" method="POST">
+				<p>
+					<input type="submit" class="button button-primary" value="<?php esc_html_e( 'Check the Files Integrity', 'health-check' ); ?>">
+				</p>
+			</form>
+
+			<div id="tools-file-integrity-response-holder">
+				<span class="spinner"></span>
+			</div>
+		</div>
+	</dd>
+
+	<dt role="heading" aria-level="2">
+		<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-2" id="health-check-accordion-heading-2" type="button">
+			<span class="title">
+				<?php esc_html_e( 'Mail Check', 'health-check' ); ?>
+			</span>
+			<span class="icon"></span>
+		</button>
+	</dt>
+	<dd id="health-check-accordion-block-2" role="region" aria-labelledby="health-check-accordion-heading-2" class="health-check-accordion-panel" hidden="hidden">
+		<div>
+			<p>
+				<?php _e( 'The Mail Check will invoke the <code>wp_mail()</code> function and check if it succeeds. We will use the E-mail address you have set up, but you can change it below if you like.', 'health-check' ); ?>
+			</p>
+			<form action="#" id="health-check-mail-check" method="POST">
+				<table class="widefat tools-email-table">
+					<tr>
+						<td>
+							<p>
+								<?php
 								$current_user = wp_get_current_user();
-							?>
-							<label for="email"><?php _e( 'E-mail', 'health-check' ); ?></label>
-							<input type="text" name="email" id="email" value="<?php echo $current_user->user_email; ?>">
-						</p>
-					</td>
-					<td>
-					<p>
-						<label for="email_message"><?php _e( 'Additional message', 'health-check' ); ?></label>
-						<input type="text" name="email_message" id="email_message" value="">
-					</p>
-					</td>
-				</tr>
-			</table>
-			<input type="submit" class="button button-primary" value="<?php esc_html_e( 'Send test mail', 'health-check' ); ?>">
-		</form>
-	</div>
-	<div id="tools-mail-check-response-holder">
-		<span class="spinner"></span>
-	</div>
-</div>
+								?>
+								<label for="email"><?php _e( 'E-mail', 'health-check' ); ?></label>
+								<input type="text" name="email" id="email" value="<?php echo $current_user->user_email; ?>">
+							</p>
+						</td>
+						<td>
+							<p>
+								<label for="email_message"><?php _e( 'Additional message', 'health-check' ); ?></label>
+								<input type="text" name="email_message" id="email_message" value="">
+							</p>
+						</td>
+					</tr>
+				</table>
+				<input type="submit" class="button button-primary" value="<?php esc_html_e( 'Send test mail', 'health-check' ); ?>">
+			</form>
+
+			<div id="tools-mail-check-response-holder">
+				<span class="spinner"></span>
+			</div>
+		</div>
+	</dd>
+</dl>
+
 <?php
 include_once( HEALTH_CHECK_PLUGIN_DIRECTORY . '/modals/diff.php' );


### PR DESCRIPTION
The tools tab can easily lead to information overload, especially if more tools are introduced over time.

To help with this, splitting up the page using an accordion style is very handy, it's accessibility friendly (keyboard accessible and aria-described as recommended by the W3) and allows us to only show data relevant to individual tasks in a more grouped fashion.