### PR TITLE
Backup plugins list

### DIFF
--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -2,7 +2,7 @@
 /*
 	Plugin Name: Health Check Troubleshooting Mode
 	Description: Conditionally disabled themes or plugins on your site for a given session, used to rule out conflicts during troubleshooting.
-	Version: 1.3
+	Version: 1.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -419,6 +419,10 @@ class Health_Check_Troubleshooting_MU {
 		delete_option( 'health-check-allowed-plugins' );
 		delete_option( 'health-check-default-theme' );
 		delete_option( 'health-check-current-theme' );
+
+		update_option( 'active_plugins', get_option( 'health-check-backup-plugin-list' ) );
+
+		delete_option( 'health-check-backup-plugin-list' );
 	}
 
 	/**

--- a/src/includes/class-health-check-troubleshoot.php
+++ b/src/includes/class-health-check-troubleshoot.php
@@ -10,6 +10,19 @@
  */
 class Health_Check_Troubleshoot {
 
+	/**
+	 * Initiate the troubleshooting mode by setting meta data and cookies.
+	 *
+	 * @uses is_array()
+	 * @uses md5()
+	 * @uses rand()
+	 * @uses update_option()
+	 * @uses setcookie()
+	 *
+	 * @param array $allowed_plugins An array of plugins that may be active right away.
+	 *
+	 * @return void
+	 */
 	static function initiate_troubleshooting_mode( $allowed_plugins = array() ) {
 		if ( ! is_array( $allowed_plugins ) ) {
 			$allowed_plugins = (array) $allowed_plugins;
@@ -20,6 +33,8 @@ class Health_Check_Troubleshoot {
 		update_option( 'health-check-allowed-plugins', $allowed_plugins );
 
 		update_option( 'health-check-disable-plugin-hash', $loopback_hash );
+
+		update_option( 'health-check-backup-plugin-list', get_option( 'active_plugins' ) );
 
 		setcookie( 'health-check-disable-plugins', $loopback_hash, 0, COOKIEPATH, COOKIE_DOMAIN );
 	}
@@ -41,7 +56,7 @@ class Health_Check_Troubleshoot {
 				'page' => 'health-check',
 				'tab'  => 'troubleshoot',
 			),
-			admin_url() ) );
+		admin_url() ) );
 		$creds = request_filesystem_credentials( $url, '', false, WP_CONTENT_DIR, array( 'health-check-troubleshoot-mode', 'action' ) );
 		if ( false === $creds ) {
 			return false;

--- a/src/includes/class-health-check-troubleshoot.php
+++ b/src/includes/class-health-check-troubleshoot.php
@@ -10,6 +10,20 @@
  */
 class Health_Check_Troubleshoot {
 
+	static function initiate_troubleshooting_mode( $allowed_plugins = array() ) {
+		if ( ! is_array( $allowed_plugins ) ) {
+			$allowed_plugins = (array) $allowed_plugins;
+		}
+
+		$loopback_hash = md5( rand() );
+
+		update_option( 'health-check-allowed-plugins', $allowed_plugins );
+
+		update_option( 'health-check-disable-plugin-hash', $loopback_hash );
+
+		setcookie( 'health-check-disable-plugins', $loopback_hash, 0, COOKIEPATH, COOKIE_DOMAIN );
+	}
+
 	/**
 	 * Conditionally show a form for providing filesystem credentials when introducing our troubleshooting mode plugin.
 	 *
@@ -27,7 +41,7 @@ class Health_Check_Troubleshoot {
 				'page' => 'health-check',
 				'tab'  => 'troubleshoot',
 			),
-		admin_url() ) );
+			admin_url() ) );
 		$creds = request_filesystem_credentials( $url, '', false, WP_CONTENT_DIR, array( 'health-check-troubleshoot-mode', 'action' ) );
 		if ( false === $creds ) {
 			return false;
@@ -251,7 +265,7 @@ class Health_Check_Troubleshoot {
 			}
 		}
 
-?>
+		?>
 		<div class="notice inline">
 			<form action="" method="post" class="form" style="text-align: center;">
 				<input type="hidden" name="health-check-troubleshoot-mode" value="true">
@@ -264,6 +278,6 @@ class Health_Check_Troubleshoot {
 			</form>
 		</div>
 
-<?php
+		<?php
 	}
 }

--- a/src/includes/class-healthcheck.php
+++ b/src/includes/class-healthcheck.php
@@ -87,10 +87,7 @@ class HealthCheck {
 	 * Catch when the troubleshooting form has been submitted, and appropriately set required options and cookies.
 	 *
 	 * @uses current_user_can()
-	 * @uses md5()
-	 * @uses rand()
-	 * @uses update_option()
-	 * @uses setcookie()
+	 * @uses Health_Check_Troubleshoot::initiate_troubleshooting_mode()
 	 *
 	 * @return void
 	 */
@@ -99,10 +96,7 @@ class HealthCheck {
 			return;
 		}
 
-		$loopback_hash = md5( rand() );
-		update_option( 'health-check-disable-plugin-hash', $loopback_hash );
-
-		setcookie( 'health-check-disable-plugins', $loopback_hash, 0, COOKIEPATH, COOKIE_DOMAIN );
+		Health_Check_Troubleshoot::initiate_troubleshooting_mode();
 	}
 
 	/**
@@ -112,10 +106,13 @@ class HealthCheck {
 	 * required options and cookies.
 	 *
 	 * @uses current_user_can()
-	 * @uses md5()
-	 * @uses rand()
-	 * @uses update_option()
-	 * @uses setcookie()
+	 * @uses ob_start()
+	 * @uses Health_Check_Troubleshoot::mu_plugin_exists()
+	 * @uses Health_Check_Troubleshoot::get_filesystem_credentials()
+	 * @uses Health_Check_Troubleshoot::setup_must_use_plugin()
+	 * @uses Health_Check_Troubleshoot::maybe_update_must_use_plugin()
+	 * @uses ob_get_clean()
+	 * @uses Health_Check_Troubleshoot::initiate_troubleshooting_mode()
 	 * @uses wp_redirect()
 	 * @uses admin_url()
 	 *
@@ -155,14 +152,9 @@ class HealthCheck {
 			return;
 		}
 
-		$loopback_hash = md5( rand() );
-		update_option( 'health-check-disable-plugin-hash', $loopback_hash );
-
-		update_option( 'health-check-allowed-plugins', array(
+		Health_Check_Troubleshoot::initiate_troubleshooting_mode( array(
 			$_GET['health-check-troubleshoot-plugin'] => $_GET['health-check-troubleshoot-plugin'],
 		) );
-
-		setcookie( 'health-check-disable-plugins', $loopback_hash, 0, COOKIEPATH, COOKIE_DOMAIN );
 
 		wp_redirect( admin_url( 'plugins.php' ) );
 	}

--- a/src/uninstall.php
+++ b/src/uninstall.php
@@ -16,6 +16,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 delete_option( 'health-check-disable-plugin-hash' );
 delete_option( 'health-check-default-theme' );
 delete_option( 'health-check-current-theme' );
+delete_option( 'health-check-backup-plugin-list' );
 
 /*
  * Remove any user meta entries we made, done with a custom query as core


### PR DESCRIPTION
Make a backup database entry of the active plugins when enabling Troubleshooting Mode, and hard-revert to that entry when leaving that mode to ensure no active plugins data is accidentally lost.

This is an attempt to improve the experience for the edge case users who have had a bad experience where the plugins list has not been properly retained previously.