### PR TITLE
Fix fatal error

### DIFF
--- a/src/includes/class-health-check-troubleshoot.php
+++ b/src/includes/class-health-check-troubleshoot.php
@@ -268,7 +268,7 @@ class Health_Check_Troubleshoot {
 		?>
 		<div class="notice inline">
 
-		<?php if ( class_exists( 'Health_Check_Troubleshooting_MU' ) && Health_Check_Troubleshooting_MU::is_troubleshooting() ) : ?>
+		<?php if ( class_exists( 'Health_Check_Troubleshooting_MU' ) && is_callable( array( 'Health_Check_Troubleshooting_MU', 'is_troubleshooting' ) ) && Health_Check_Troubleshooting_MU::is_troubleshooting() ) : ?>
 
 			<p style="text-align: center;">
 				<a class="button button-primary" href="<?php echo esc_url( add_query_arg( array( 'health-check-disable-troubleshooting' => true ) ) ); ?>">


### PR DESCRIPTION
Add an `is_callable()` check to the MU plugin function, to make sure we can actually access it. Fixes #123