### PR TITLE
Avoid overflowing the admin bar if many plugins exist

### DIFF
--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -503,7 +503,7 @@ class Health_Check_Troubleshooting_MU {
 		$allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
 
 		// Add a link to manage plugins if there are more than 20 set to be active.
-		if ( count( $allowed_plugins ) > 20 ) {
+		if ( count( $this->active_plugins ) > 20 ) {
 			$wp_menu->add_node( array(
 				'id'     => 'health-check-plugins',
 				'title'  => esc_html__( 'Manage active plugins', 'health-check' ),


### PR DESCRIPTION
We've got logic in place to avoid listing plugins in the admin bar if there are too many, to avoid overflowing the screen, and make it a better user experience.

We had a flaw in the logic, and it was still displaying for users, this is corrected here.