### PR TITLE
Change the plugin title to better relay what features it performs.

### DIFF
--- a/src/health-check.php
+++ b/src/health-check.php
@@ -4,7 +4,7 @@
  *
  * @package Health Check
  *
- * Plugin Name: Health Check
+ * Plugin Name: Health Check & Troubleshooting
  * Plugin URI: http://wordpress.org/plugins/health-check/
  * Description: Checks the health of your WordPress install.
  * Author: The WordPress.org community

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -1,4 +1,4 @@
-=== Health Check ===
+=== Health Check & Troubleshooting ===
 Tags: health check
 Contributors: wordpressdotorg, westi, pento, Clorith
 Requires at least: 3.8


### PR DESCRIPTION
The plugin serves two main purposes, it provides a site status for end users, but it also allows supporters a tool to help troubleshoot conflicts and other scenarios much more easily.

Let's relay that slightly better by adding `Troubleshooting` to the plugin title.