### PR TITLE
Make modal dismissable (and more readable) on smaller viewports.

### DIFF
--- a/assets/sass/modules/_modal.scss
+++ b/assets/sass/modules/_modal.scss
@@ -1,9 +1,9 @@
 .health-check-modal {
 
 	display: none;
-	position: fixed;
+	position: absolute;
 	z-index: 1000;
-	padding-top: 100px;
+	padding-top: 50px;
 	left: 0;
 	top: 0;
 	width: 100%;
@@ -11,6 +11,11 @@
 	overflow: auto;
 	background-color: rgb(0, 0, 0);
 	background-color: rgba(0, 0, 0, 0.4);
+
+	@media all and (min-width: 1024px) {
+
+		padding-top: 100px;
+	}
 
 	&.show {
 
@@ -23,7 +28,12 @@
 		margin: auto;
 		padding: 20px;
 		border: 1px solid #888;
-		width: 30%;
+		width: 90%;
+
+		@media all and (min-width: 1024px) {
+
+			width: 30%;
+		}
 
 		.modal-close {
 


### PR DESCRIPTION
The warning we show, encouraging users to keep backups, was terrible on mobile devices, and also has some CSS that made it less than ideal to try and read in the first place on such small viewports.

This introduces styling to use the whole viewport when applicable, and ensures you can actually scroll to read everything on mobile.