### PR TITLE
Improve the warning on the plugins screen

### DIFF
--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -174,8 +174,10 @@ class Health_Check_Troubleshooting_MU {
 		}
 
 		printf(
-			'<div class="notice notice-warning"><p>%s</p></div>',
-			esc_html__( 'Plugin actions are not available while in Troubleshooting Mode.', 'health-check' )
+			'<div class="notice notice-warning"><p>%s</p><p>%s</p><p>%s</p></div>',
+			esc_html__( 'Plugin actions are not available while in Troubleshooting Mode.', 'health-check' ),
+			esc_html__( 'By enabling the Troubleshooting Mode, all plugins will appear inactive and your site will switch to the default theme only for you. All other users will see your site as usual.', 'health-check' ),
+			esc_html__( 'A Troubleshooting Mode menu is added to your admin bar, which will allow you to enable plugins individually, switch back to your current theme, and disable Troubleshooting Mode.', 'health-check' )
 		);
 	}
 


### PR DESCRIPTION
We see users enter Troubleshooting Mode from the plugins screen without realizing what they are doing, leaving them in a state of panic.

Replicating parts of our TS warning if you've entered this mode means they know what's going on, and how to disable the mode, without introducing new strings, we're just replicating existing ones which works well for a minor fix.