### PR TITLE
Update the Grunt copy task

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -66,7 +66,7 @@ module.exports = function( grunt ) {
 			},
 			documents: {
 				cwd: 'docs/plugin/',
-				src: '**/*',
+				src: [ '**/*', '!assets/*' ],
 				dest: 'build/',
 				expand: true
 			}


### PR DESCRIPTION
Make sure we don't copy .org plugin assets when copying plugin documents to the `build` directory.