### PR TITLE
Smoother variables and higher minimum versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,32 +27,32 @@ matrix:
     - php: 7.2
       env: WP_HC_CS_TEST=yes
     - php: 7.2
-      env: WP_VERSION=3.9
+      env: WP_VERSION=4.8
     - php: 7.1
     - php: 7.1
-      env: WP_VERSION=3.9
+      env: WP_VERSION=4.7
     - php: 7.0
     - php: 7.0
-      env: WP_VERSION=3.9
+      env: WP_VERSION=4.6
     - php: 5.6
     - php: 5.6
-      env: WP_VERSION=3.8
+      env: WP_VERSION=4.5
     - php: 5.5
     - php: 5.5
-      env: WP_VERSION=3.8
+      env: WP_VERSION=4.4
     - php: 5.4
     - php: 5.4
-      env: WP_VERSION=3.8
+      env: WP_VERSION=4.3
     - php: 5.3
       dist: precise
     - php: 5.3
       dist: precise
-      env: WP_VERSION=3.8
+      env: WP_VERSION=4.2
     - php: 5.2
       dist: precise
     - php: 5.2
       dist: precise
-      env: WP_VERSION=3.8
+      env: WP_VERSION=4.1
 
 # Setup NPM modules for Travis CI cache maintanence.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,19 @@ matrix:
     - php: 7.2
       env: WP_HC_CS_TEST=yes
     - php: 7.2
-      env: WP_VERSION=4.8
+      env: WP_VERSION=4.0
     - php: 7.1
     - php: 7.1
-      env: WP_VERSION=4.7
+      env: WP_VERSION=4.0
     - php: 7.0
     - php: 7.0
-      env: WP_VERSION=4.6
+      env: WP_VERSION=4.0
     - php: 5.6
     - php: 5.6
-      env: WP_VERSION=4.5
+      env: WP_VERSION=4.0
     - php: 5.5
     - php: 5.5
-      env: WP_VERSION=4.4
+      env: WP_VERSION=4.0
     - php: 5.4
     - php: 5.4
       env: WP_VERSION=4.0
@@ -47,12 +47,12 @@ matrix:
       dist: precise
     - php: 5.3
       dist: precise
-      env: WP_VERSION=3.9
+      env: WP_VERSION=4.0
     - php: 5.2
       dist: precise
     - php: 5.2
       dist: precise
-      env: WP_VERSION=3.9
+      env: WP_VERSION=4.0
 
 # Setup NPM modules for Travis CI cache maintanence.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,17 +42,17 @@ matrix:
       env: WP_VERSION=4.4
     - php: 5.4
     - php: 5.4
-      env: WP_VERSION=4.3
+      env: WP_VERSION=4.0
     - php: 5.3
       dist: precise
     - php: 5.3
       dist: precise
-      env: WP_VERSION=4.2
+      env: WP_VERSION=3.9
     - php: 5.2
       dist: precise
     - php: 5.2
       dist: precise
-      env: WP_VERSION=4.1
+      env: WP_VERSION=3.9
 
 # Setup NPM modules for Travis CI cache maintanence.
 cache:

--- a/docs/plugin/readme.txt
+++ b/docs/plugin/readme.txt
@@ -1,7 +1,7 @@
 === Health Check & Troubleshooting ===
 Tags: health check
 Contributors: wordpressdotorg, westi, pento, Clorith
-Requires at least: 3.8
+Requires at least: 4.0
 Tested up to: 4.9
 Stable tag: 1.1.2
 License: GPLv2

--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -746,7 +746,7 @@ class Health_Check_Troubleshooting_MU {
 	}
 
 	public function dashboard_widget_styles() {
-		if ( !  $this->is_troubleshooting() ) {
+		if ( ! $this->is_troubleshooting() ) {
 			return;
 		}
 

--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -80,6 +80,15 @@ class Health_Check_Troubleshooting_MU {
 		 */
 		add_action( 'activated_plugin', array( $this, 'plugin_activated' ) );
 
+		$this->load_options();
+	}
+
+	/**
+	 * Set up the class variables based on option table entries.
+	 *
+	 * @return void
+	 */
+	public function load_options() {
 		$this->disable_hash    = get_option( 'health-check-disable-plugin-hash', null );
 		$this->allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
 		$this->default_theme   = ( 'yes' === get_option( 'health-check-default-theme', 'yes' ) ? true : false );

--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -14,6 +14,7 @@ class Health_Check_Troubleshooting_MU {
 	private $override_active = true;
 	private $default_theme   = true;
 	private $active_plugins  = array();
+	private $allowed_plugins = array();
 	private $current_theme;
 	private $current_theme_details;
 	private $self_fetching_theme = false;
@@ -79,10 +80,11 @@ class Health_Check_Troubleshooting_MU {
 		 */
 		add_action( 'activated_plugin', array( $this, 'plugin_activated' ) );
 
-		$this->disable_hash   = get_option( 'health-check-disable-plugin-hash', null );
-		$this->default_theme  = ( 'yes' === get_option( 'health-check-default-theme', 'yes' ) ? true : false );
-		$this->active_plugins = $this->get_unfiltered_plugin_list();
-		$this->current_theme  = get_option( 'health-check-current-theme', false );
+		$this->disable_hash    = get_option( 'health-check-disable-plugin-hash', null );
+		$this->allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
+		$this->default_theme   = ( 'yes' === get_option( 'health-check-default-theme', 'yes' ) ? true : false );
+		$this->active_plugins  = $this->get_unfiltered_plugin_list();
+		$this->current_theme   = get_option( 'health-check-current-theme', false );
 	}
 
 	/**
@@ -201,11 +203,9 @@ class Health_Check_Troubleshooting_MU {
 			$plugin_data['slug'] = $plugin_file;
 		}
 
-		$allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
-
 		$plugin_slug = ( isset( $plugin_data['slug'] ) ? $plugin_data['slug'] : sanitize_title( $plugin_data['Name'] ) );
 
-		if ( in_array( $plugin_slug, $allowed_plugins ) ) {
+		if ( in_array( $plugin_slug, $this->allowed_plugins ) ) {
 			$actions['troubleshoot-disable'] = sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( add_query_arg( array(
@@ -283,11 +283,9 @@ class Health_Check_Troubleshooting_MU {
 			return $plugins;
 		}
 
-		$allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
-
 		// If we've received a comma-separated list of allowed plugins, we'll add them to the array of allowed plugins.
 		if ( isset( $_GET['health-check-allowed-plugins'] ) ) {
-			$allowed_plugins = explode( ',', $_GET['health-check-allowed-plugins'] );
+			$this->allowed_plugins = explode( ',', $_GET['health-check-allowed-plugins'] );
 		}
 
 		foreach ( $plugins as $plugin_no => $plugin_path ) {
@@ -295,7 +293,7 @@ class Health_Check_Troubleshooting_MU {
 			$plugin_parts = explode( '/', $plugin_path );
 
 			// We may want to allow individual, or groups of plugins, so introduce a skip-mechanic for those scenarios.
-			if ( in_array( $plugin_parts[0], $allowed_plugins ) ) {
+			if ( in_array( $plugin_parts[0], $this->allowed_plugins ) ) {
 				continue;
 			}
 
@@ -474,7 +472,7 @@ class Health_Check_Troubleshooting_MU {
 		}
 
 		// Dismiss notices.
-		if ( isset( $_GET['health-check-dismiss-notices'] ) && Health_Check_Troubleshooting_MU::is_troubleshooting() && is_admin() ) {
+		if ( isset( $_GET['health-check-dismiss-notices'] ) && $this->is_troubleshooting() && is_admin() ) {
 			update_option( 'health-check-dashboard-notices', array() );
 
 			wp_redirect( admin_url() );
@@ -483,15 +481,14 @@ class Health_Check_Troubleshooting_MU {
 
 		// Enable an individual plugin.
 		if ( isset( $_GET['health-check-troubleshoot-enable-plugin'] ) ) {
-			$allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
+			$old_allowed_plugins = $this->allowed_plugins;
 
-			$old_allowed_plugins = $allowed_plugins;
+			$this->allowed_plugins[ $_GET['health-check-troubleshoot-enable-plugin'] ] = $_GET['health-check-troubleshoot-enable-plugin'];
 
-			$allowed_plugins[ $_GET['health-check-troubleshoot-enable-plugin'] ] = $_GET['health-check-troubleshoot-enable-plugin'];
-
-			update_option( 'health-check-allowed-plugins', $allowed_plugins );
+			update_option( 'health-check-allowed-plugins', $this->allowed_plugins );
 
 			if ( ! $this->test_site_state() ) {
+				$this->allowed_plugins = $old_allowed_plugins;
 				update_option( 'health-check-allowed-plugins', $old_allowed_plugins );
 
 				$this->add_dashboard_notice(
@@ -510,15 +507,14 @@ class Health_Check_Troubleshooting_MU {
 
 		// Disable an individual plugin.
 		if ( isset( $_GET['health-check-troubleshoot-disable-plugin'] ) ) {
-			$allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
+			$old_allowed_plugins = $this->allowed_plugins;
 
-			$old_allowed_plugins = $allowed_plugins;
+			unset( $this->allowed_plugins[ $_GET['health-check-troubleshoot-disable-plugin'] ] );
 
-			unset( $allowed_plugins[ $_GET['health-check-troubleshoot-disable-plugin'] ] );
-
-			update_option( 'health-check-allowed-plugins', $allowed_plugins );
+			update_option( 'health-check-allowed-plugins', $this->allowed_plugins );
 
 			if ( ! $this->test_site_state() ) {
+				$this->allowed_plugins = $old_allowed_plugins;
 				update_option( 'health-check-allowed-plugins', $old_allowed_plugins );
 
 				$this->add_dashboard_notice(
@@ -601,8 +597,6 @@ class Health_Check_Troubleshooting_MU {
 			'title' => esc_html__( 'Troubleshooting Mode', 'health-check' ),
 		) );
 
-		$allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
-
 		// Add a link to manage plugins if there are more than 20 set to be active.
 		if ( count( $this->active_plugins ) > 20 ) {
 			$wp_menu->add_node( array(
@@ -635,7 +629,7 @@ class Health_Check_Troubleshooting_MU {
 
 				$enabled = true;
 
-				if ( in_array( $plugin_slug, $allowed_plugins ) ) {
+				if ( in_array( $plugin_slug, $this->allowed_plugins ) ) {
 					$label = sprintf(
 						// Translators: %s: Plugin slug.
 						esc_html__( 'Disable %s', 'health-check' ),
@@ -743,7 +737,7 @@ class Health_Check_Troubleshooting_MU {
 	}
 
 	public function dashboard_widget_styles() {
-		if ( ! Health_Check_Troubleshooting_MU::is_troubleshooting() ) {
+		if ( !  $this->is_troubleshooting() ) {
 			return;
 		}
 
@@ -810,7 +804,7 @@ class Health_Check_Troubleshooting_MU {
 	}
 
 	public function dashboard_widget_scripts() {
-		if ( ! Health_Check_Troubleshooting_MU::is_troubleshooting() ) {
+		if ( ! $this->is_troubleshooting() ) {
 			return;
 		}
 
@@ -837,7 +831,7 @@ class Health_Check_Troubleshooting_MU {
 	}
 
 	public function display_dashboard_widget() {
-		if ( ! Health_Check_Troubleshooting_MU::is_troubleshooting() ) {
+		if ( ! $this->is_troubleshooting() ) {
 			return;
 		}
 
@@ -921,7 +915,6 @@ class Health_Check_Troubleshooting_MU {
 									<?php
 									$active_plugins   = array();
 									$inactive_plugins = array();
-									$allowed_plugins  = get_option( 'health-check-allowed-plugins', array() );
 
 									foreach ( $this->active_plugins as $count => $single_plugin ) {
 										$plugin_slug = explode( '/', $single_plugin );
@@ -936,7 +929,7 @@ class Health_Check_Troubleshooting_MU {
 
 										$actions = array();
 
-										if ( in_array( $plugin_slug, $allowed_plugins ) ) {
+										if ( in_array( $plugin_slug, $this->allowed_plugins ) ) {
 											$actions[] = sprintf(
 												'<a href="%s" aria-label="%s">%s</a>',
 												esc_url( add_query_arg( array(

--- a/tests/phpunit/test-mu-plugin.php
+++ b/tests/phpunit/test-mu-plugin.php
@@ -75,6 +75,9 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 		// Add Akismet to the approved plugins list.
 		update_option( 'health-check-allowed-plugins', array( 'akismet' ) );
 
+		// Re-load the options entries so we know they're after our changes.
+		$this->class_instance->load_options();
+
 		// Fetch a list of all active plugins while troubleshooting.
 		$all_plugins = get_option( 'active_plugins' );
 
@@ -85,5 +88,9 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 
 		// Empty out the approved plugins list after asserting tests.
 		update_option( 'health-check-allowed-plugins', array() );
+
+		// Re-load the options entries so we know they're after our changes.
+		$this->class_instance->load_options();
+
 	}
 }


### PR DESCRIPTION
This raises the minimum supported WordPress version to 4.0, this is due to lower versions having inconsistent behaviors relating to the plugins DB entry and, in repeated tests, losing active plugin entries.

It also stores more data inside the MU plugin object, to avoid repeated DB calls for reused data.