### PR TITLE
Fix update filter check

### DIFF
--- a/src/includes/class-health-check-auto-updates.php
+++ b/src/includes/class-health-check-auto-updates.php
@@ -140,7 +140,26 @@ class Health_Check_Auto_Updates {
 	 * @return array
 	 */
 	function test_wp_version_check_attached() {
-		if ( ! has_filter( 'wp_version_check', 'wp_version_check' ) ) {
+		$cookies = wp_unslash( $_COOKIE );
+		$timeout = 10;
+		$headers = array(
+			'Cache-Control' => 'no-cache',
+		);
+
+		// Include Basic auth in loopback requests.
+		if ( isset( $_SERVER['PHP_AUTH_USER'] ) && isset( $_SERVER['PHP_AUTH_PW'] ) ) {
+			$headers['Authorization'] = 'Basic ' . base64_encode( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) . ':' . wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
+		}
+
+		$url = add_query_arg( array(
+				'health-check-test-wp_version_check' => true,
+			), admin_url() );
+
+		$test = wp_remote_get( $url, compact( 'cookies', 'headers', 'timeout' ) );
+
+		$response = wp_remote_retrieve_body( $test );
+
+		if ( 'yes' !== $response ) {
 			return array(
 				'desc'     => sprintf(
 					/* translators: %s: Name of the filter used. */

--- a/src/includes/class-health-check-auto-updates.php
+++ b/src/includes/class-health-check-auto-updates.php
@@ -152,8 +152,8 @@ class Health_Check_Auto_Updates {
 		}
 
 		$url = add_query_arg( array(
-				'health-check-test-wp_version_check' => true,
-			), admin_url() );
+			'health-check-test-wp_version_check' => true,
+		), admin_url() );
 
 		$test = wp_remote_get( $url, compact( 'cookies', 'headers', 'timeout' ) );
 

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -24,6 +24,8 @@ class Health_Check_Site_Status {
 		$this->prepare_sql_data();
 
 		add_action( 'wp_ajax_health-check-site-status', array( $this, 'site_status' ) );
+
+		add_action( 'wp_loaded', array( $this, 'check_wp_version_check_exists' ) );
 	}
 
 	private function prepare_sql_data() {
@@ -50,6 +52,16 @@ class Health_Check_Site_Status {
 
 		$this->mysql_min_version_check = version_compare( HEALTH_CHECK_MYSQL_MIN_VERSION, $this->mysql_server_version, '<=' );
 		$this->mysql_rec_version_check = version_compare( $this->health_check_mysql_rec_version, $this->mysql_server_version, '<=' );
+	}
+
+	public function check_wp_version_check_exists() {
+		if ( ! is_admin() || ! is_user_logged_in() || ! current_user_can( 'manage_options' ) || ! isset( $_GET['health-check-test-wp_version_check'] ) ) {
+			return;
+		}
+
+		echo ( has_filter( 'wp_version_check', 'wp_version_check' ) ? 'yes' : 'no' );
+
+		die();
 	}
 
 	public function site_status() {


### PR DESCRIPTION
We made the site status screen a bit more flexible, and faster loading by running tests via AJAX calls.

This unfortunately meant one of our background update tests failed, as AJAX calls are checked too early for this. This PR adds a direct GET request to a special URL for testing this filter directly.