### PR TITLE
Add a missing version argument

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -88,7 +88,8 @@ class Health_Check_Site_Status {
 				'<span class="warning"></span> %s',
 				sprintf(
 					// translators: %s: Your current version of WordPress.
-					esc_html__( '%s - We were unable to check if any new versions are available.', 'health-check' )
+					esc_html__( '%s - We were unable to check if any new versions are available.', 'health-check' ),
+					$core_current_version
 				)
 			);
 		} else {


### PR DESCRIPTION
When using non-standard WordPress builds, a warning was thrown because the `sprintf` call is missing the current version, this adds the version in for those scenarios as well.