### PR TITLE
Fix @package tag

### DIFF
--- a/src/health-check.php
+++ b/src/health-check.php
@@ -4,6 +4,7 @@
  *
  * @package Health Check
  *
+ * @wordpress-plugin
  * Plugin Name: Health Check & Troubleshooting
  * Plugin URI: http://wordpress.org/plugins/health-check/
  * Description: Checks the health of your WordPress install.


### PR DESCRIPTION
By adding a `@wordpress-plugin` tag, it will stop Docblock parsers from reading all of the rest of the DocBlock content as part of the `@package` tag.