### PR TITLE
Removed Extra Trailing space

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -314,7 +314,7 @@ class Health_Check_Site_Status {
 						// translators: %1$d: The amount of inactive themes. %2$s: The default theme for WordPress. %3$s: The currently active theme. %4$s: The active themes parent theme.
 						esc_html( _n(
 							'Your site has %1$d inactive theme. To enhance your sites security it is recommended to remove any unused themes. You should keep %2$s, the default WordPress theme, %3$s, your current theme and %4$s, the parent theme.',
-							'Your site has %1$d inactive themes. To enhance your sites security it is recommended to remove any unused themes. You should keep %2$s, the default WordPress theme, %3$s, your current theme and %4$s, the parent theme. ',
+							'Your site has %1$d inactive themes. To enhance your sites security it is recommended to remove any unused themes. You should keep %2$s, the default WordPress theme, %3$s, your current theme and %4$s, the parent theme.',
 							$themes_inactive,
 							'health-check'
 						) ),


### PR DESCRIPTION
This pluralized string was throwing errors about trailing space due to the plural version containing an extra trailing space.
Fixes translation string here - https://translate.wordpress.org/projects/wp-plugins/health-check/dev/en-ca/default?filters%5Boriginal_id%5D=6371511