### PR TITLE
Add capability checks for backup warning

### DIFF
--- a/src/includes/class-health-check-troubleshoot.php
+++ b/src/includes/class-health-check-troubleshoot.php
@@ -68,6 +68,23 @@ class Health_Check_Troubleshoot {
 	 * @return bool
 	 */
 	static function has_seen_warning() {
+		/**
+		 * Filter who may see the backup warning from the plugin.
+		 *
+		 * The plugin displays a warning reminding users to keep backups when active.
+		 * This filter allows anyone to declare what capability is needed to view the warning, it is set to
+		 * the `manage_options` capability by default. This means the feature is available to any site admin,
+		 * even in a multisite environment.
+		 *
+		 * @param string $capability Default manage_options. The capability required to see the warning.
+		 */
+		$capability_to_see = apply_filters( 'health_check_backup_warning_required_capability', 'manage_options' );
+
+		// If the current user lacks the capabilities to use the plugin, pretend they've seen the warning so it isn't displayed.
+		if ( ! current_user_can( $capability_to_see ) ) {
+			return true;
+		}
+
 		$meta = get_user_meta( get_current_user_id(), 'health-check', true );
 		if ( empty( $meta ) ) {
 			return false;


### PR DESCRIPTION
The warning shown in wp-admin, encouraging the use of backups and informing users where to go when reporting problems is nice.

But it's also overly active, and wants to tell _everyone_ about the importance of backups.

This PR adds a capability check, and an associated filter to allow granular control of who may see the backup warning.