### PR TITLE
Ensure the update needed variable is defined

### DIFF
--- a/src/includes/class-health-check-debug-data.php
+++ b/src/includes/class-health-check-debug-data.php
@@ -47,6 +47,7 @@ class Health_Check_Debug_Data {
 
 		$core_current_version = get_bloginfo( 'version' );
 		$core_updates         = get_core_updates();
+		$core_update_needed   = '';
 
 		foreach ( $core_updates as $core => $update ) {
 			if ( 'upgrade' === $update->response ) {


### PR DESCRIPTION
We were setting a default value for the core version upgrade, but it was inside the upgrade response, but what if there are no updates ... 🤔 

Exactly, we get a warning that the variable has not been defined, so we do that now.