### PR TITLE
Avoid duplicate warnings when viewing site statuses in troubleshooting mode

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -150,12 +150,14 @@ class Health_Check_Site_Status {
 			return false;
 		}
 
-		if ( empty( $this->disable_hash ) ) {
+		$disable_hash = get_option( 'health-check-disable-plugin-hash', null );
+
+		if ( empty( $disable_hash ) ) {
 			return false;
 		}
 
 		// If the plugin hash is not valid, we also break out
-		if ( $this->disable_hash !== $_GET['health-check-disable-plugin-hash'] ) {
+		if ( $disable_hash !== $_GET['health-check-disable-plugin-hash'] ) {
 			return false;
 		}
 


### PR DESCRIPTION
While troubleshooting, the Site Status page is intentionally left not showing how plugins are inactive.

This is because the numbers are not relevant at this point due to us modifying what is active and what isn't. Unfortunately the recent patch to fix a fatal error meant the warning would still show up.