### PR TITLE
Add web server software to the debug output

### DIFF
--- a/src/includes/class-health-check-debug-data.php
+++ b/src/includes/class-health-check-debug-data.php
@@ -376,6 +376,10 @@ class Health_Check_Debug_Data {
 			'value' => ( ! function_exists( 'php_uname' ) ? __( 'Unable to determine server architecture', 'health-check' ) : sprintf( '%s %s %s', php_uname( 's' ), php_uname( 'r' ), php_uname( 'm' ) ) ),
 		);
 		$info['wp-server']['fields'][] = array(
+			'label' => __( 'Web Server Software', 'health-check' ),
+			'value' => ( isset( $_SERVER['SERVER_SOFTWARE'] ) ? $_SERVER['SERVER_SOFTWARE'] : __( 'Unable to determine what web server software is used', 'health-check' ) ),
+		);
+		$info['wp-server']['fields'][] = array(
 			'label' => __( 'PHP Version', 'health-check' ),
 			'value' => ( ! function_exists( 'phpversion' ) ? __( 'Unable to determine PHP version', 'health-check' ) : sprintf(
 				'%s %s',


### PR DESCRIPTION
Introduces a field to the `Server` section of the debug information, providing details on what web server/httpd is used to serve up PHP files. The distinction here is that it of course won't know about any front-facing proxies, such as varnish and the likes.

![image](https://user-images.githubusercontent.com/468735/45329519-23178800-b561-11e8-84f6-3aa6fd2e93ad.png)

The information is fetched using `$_SERVER['SERVER_SOFTWARE']` if available, and shows a notice if the value isn't available.