### PR TITLE
Fixed a spelling error in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/WordPress/health-check.svg?branch=master)](https://travis-ci.org/WordPress/health-check)
 
-Health Check if a WordPress plugin that will perform a number of checks on your WordPress install to detect common configuration errors and known issues.
+Health Check is a WordPress plugin that will perform a number of checks on your WordPress install to detect common configuration errors and known issues.
 
 It currently checks your PHP and MySQL versions, some extensions which are needed or may improve WordPress, and that the WordPress.org services are accessible to you.
 


### PR DESCRIPTION
I noticed the Readme file said "Health Check if a Wordpress plugin", updated to say "Health Check is a Wordpress plugin"