### PR TITLE
Remove copy text indent

### DIFF
--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -39,7 +39,7 @@ $info = Health_Check_Debug_Data::debug_data();
 			?>
 			<div id="system-information-english-copy-wrapper" style="display: none;">
 					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`
-<?php // phpcs:ignore
+<?php // @codingStandardsIgnoreLine
 			foreach ( $english_info as $section => $details ) {
 				// Skip this section if there are no fields, or the section has been declared as private.
 				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
@@ -91,7 +91,7 @@ $info = Health_Check_Debug_Data::debug_data();
 
 		<div id="system-information-copy-wrapper" style="display: none;">
 			<textarea id="system-information-copy-field" class="widefat" rows="10">`
-<?php // phpcs:ignore
+<?php // @codingStandardsIgnoreLine
 			foreach ( $info as $section => $details ) {
 				// Skip this section if there are no fields, or the section has been declared as private.
 				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {

--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -39,7 +39,7 @@ $info = Health_Check_Debug_Data::debug_data();
 			?>
 			<div id="system-information-english-copy-wrapper" style="display: none;">
 					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`
-			<?php
+<?php // @codingStandardsIgnoreLine
 			foreach ( $english_info as $section => $details ) {
 				// Skip this section if there are no fields, or the section has been declared as private.
 				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
@@ -91,7 +91,7 @@ $info = Health_Check_Debug_Data::debug_data();
 
 		<div id="system-information-copy-wrapper" style="display: none;">
 			<textarea id="system-information-copy-field" class="widefat" rows="10">`
-			<?php
+<?php // @codingStandardsIgnoreLine
 			foreach ( $info as $section => $details ) {
 				// Skip this section if there are no fields, or the section has been declared as private.
 				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {

--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -38,7 +38,8 @@ $info = Health_Check_Debug_Data::debug_data();
 			}
 			?>
 			<div id="system-information-english-copy-wrapper" style="display: none;">
-					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`<?php
+					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`
+<?php
 						foreach ( $english_info as $section => $details ) {
 							// Skip this section if there are no fields, or the section has been declared as private.
 							if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
@@ -89,7 +90,8 @@ $info = Health_Check_Debug_Data::debug_data();
 	<?php endif; ?>
 
 		<div id="system-information-copy-wrapper" style="display: none;">
-			<textarea id="system-information-copy-field" class="widefat" rows="10">`<?php
+			<textarea id="system-information-copy-field" class="widefat" rows="10">`
+<?php
 				foreach ( $info as $section => $details ) {
 					// Skip this section if there are no fields, or the section has been declared as private.
 					if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {

--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -39,7 +39,7 @@ $info = Health_Check_Debug_Data::debug_data();
 			?>
 			<div id="system-information-english-copy-wrapper" style="display: none;">
 					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`
-<?php // @codingStandardsIgnoreLine
+<?php // phpcs:ignore
 			foreach ( $english_info as $section => $details ) {
 				// Skip this section if there are no fields, or the section has been declared as private.
 				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
@@ -91,7 +91,7 @@ $info = Health_Check_Debug_Data::debug_data();
 
 		<div id="system-information-copy-wrapper" style="display: none;">
 			<textarea id="system-information-copy-field" class="widefat" rows="10">`
-<?php // @codingStandardsIgnoreLine
+<?php // phpcs:ignore
 			foreach ( $info as $section => $details ) {
 				// Skip this section if there are no fields, or the section has been declared as private.
 				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {

--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -38,8 +38,7 @@ $info = Health_Check_Debug_Data::debug_data();
 			}
 			?>
 			<div id="system-information-english-copy-wrapper" style="display: none;">
-					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`
-						<?php
+					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`<?php
 						foreach ( $english_info as $section => $details ) {
 							// Skip this section if there are no fields, or the section has been declared as private.
 							if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
@@ -90,8 +89,7 @@ $info = Health_Check_Debug_Data::debug_data();
 	<?php endif; ?>
 
 		<div id="system-information-copy-wrapper" style="display: none;">
-			<textarea id="system-information-copy-field" class="widefat" rows="10">`
-				<?php
+			<textarea id="system-information-copy-field" class="widefat" rows="10">`<?php
 				foreach ( $info as $section => $details ) {
 					// Skip this section if there are no fields, or the section has been declared as private.
 					if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {

--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -39,46 +39,46 @@ $info = Health_Check_Debug_Data::debug_data();
 			?>
 			<div id="system-information-english-copy-wrapper" style="display: none;">
 					<textarea id="system-information-english-copy-field" class="widefat" rows="10">`
-<?php
-						foreach ( $english_info as $section => $details ) {
-							// Skip this section if there are no fields, or the section has been declared as private.
-							if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
-								continue;
-							}
+			<?php
+			foreach ( $english_info as $section => $details ) {
+				// Skip this section if there are no fields, or the section has been declared as private.
+				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
+					continue;
+				}
 
-							printf(
-								"### %s%s ###\n\n",
-								$details['label'],
-								( isset( $details['show_count'] ) && $details['show_count'] ? sprintf( ' (%d)', count( $details['fields'] ) ) : '' )
+				printf(
+					"### %s%s ###\n\n",
+					$details['label'],
+					( isset( $details['show_count'] ) && $details['show_count'] ? sprintf( ' (%d)', count( $details['fields'] ) ) : '' )
+				);
+
+				foreach ( $details['fields'] as $field ) {
+					if ( isset( $field['private'] ) && true === $field['private'] ) {
+						continue;
+					}
+
+					$values = $field['value'];
+					if ( is_array( $field['value'] ) ) {
+						$values = '';
+
+						foreach ( $field['value'] as $name => $value ) {
+							$values .= sprintf(
+								"\n\t%s: %s",
+								$name,
+								$value
 							);
-
-							foreach ( $details['fields'] as $field ) {
-								if ( isset( $field['private'] ) && true === $field['private'] ) {
-									continue;
-								}
-
-								$values = $field['value'];
-								if ( is_array( $field['value'] ) ) {
-									$values = '';
-
-									foreach ( $field['value'] as $name => $value ) {
-										$values .= sprintf(
-											"\n\t%s: %s",
-											$name,
-											$value
-										);
-									}
-								}
-
-								printf(
-									"%s: %s\n",
-									$field['label'],
-									$values
-								);
-							}
-							echo "\n";
 						}
-						?>
+					}
+
+					printf(
+						"%s: %s\n",
+						$field['label'],
+						$values
+					);
+				}
+				echo "\n";
+			}
+			?>
 `</textarea>
 			<p>
 				<?php esc_html_e( 'Some information may be filtered out from the list you are about to copy, this is information that may be considered private, and is not meant to be shared in a public forum.', 'health-check' ); ?>
@@ -91,46 +91,46 @@ $info = Health_Check_Debug_Data::debug_data();
 
 		<div id="system-information-copy-wrapper" style="display: none;">
 			<textarea id="system-information-copy-field" class="widefat" rows="10">`
-<?php
-				foreach ( $info as $section => $details ) {
-					// Skip this section if there are no fields, or the section has been declared as private.
-					if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
+			<?php
+			foreach ( $info as $section => $details ) {
+				// Skip this section if there are no fields, or the section has been declared as private.
+				if ( empty( $details['fields'] ) || ( isset( $details['private'] ) && $details['private'] ) ) {
+					continue;
+				}
+
+				printf(
+					"### %s%s ###\n\n",
+					$details['label'],
+					( isset( $details['show_count'] ) && $details['show_count'] ? sprintf( ' (%d)', count( $details['fields'] ) ) : '' )
+				);
+
+				foreach ( $details['fields'] as $field ) {
+					if ( isset( $field['private'] ) && true === $field['private'] ) {
 						continue;
 					}
 
-					printf(
-						"### %s%s ###\n\n",
-						$details['label'],
-						( isset( $details['show_count'] ) && $details['show_count'] ? sprintf( ' (%d)', count( $details['fields'] ) ) : '' )
-					);
+					$values = $field['value'];
+					if ( is_array( $field['value'] ) ) {
+						$values = '';
 
-					foreach ( $details['fields'] as $field ) {
-						if ( isset( $field['private'] ) && true === $field['private'] ) {
-							continue;
+						foreach ( $field['value'] as $name => $value ) {
+							$values .= sprintf(
+								"\n\t%s: %s",
+								$name,
+								$value
+							);
 						}
-
-						$values = $field['value'];
-						if ( is_array( $field['value'] ) ) {
-							$values = '';
-
-							foreach ( $field['value'] as $name => $value ) {
-								$values .= sprintf(
-									"\n\t%s: %s",
-									$name,
-									$value
-								);
-							}
-						}
-
-						printf(
-							"%s: %s\n",
-							$field['label'],
-							$values
-						);
 					}
-					echo "\n";
+
+					printf(
+						"%s: %s\n",
+						$field['label'],
+						$values
+					);
 				}
-				?>
+				echo "\n";
+			}
+			?>
 `</textarea>
 			<p>
 				<?php esc_html_e( 'Some information may be filtered out from the list you are about to copy, this is information that may be considered private, and is not meant to be shared in a public forum.', 'health-check' ); ?>


### PR DESCRIPTION
To remove the whitespace that adds extra indentation in src/pages/debug-data.php
issue https://github.com/WordPress/health-check/issues/176