### PR TITLE
Add tagline to readme, resolves #132

### DIFF
--- a/docs/plugin/readme.txt
+++ b/docs/plugin/readme.txt
@@ -7,6 +7,8 @@ Stable tag: 1.2.1
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
+Health Check identifies common problems, and helps you troubleshoot plugin and theme conflicts.
+
 == Description ==
 
 This plugin will perform a number of checks on your WordPress install to detect common configuration errors and known issues.


### PR DESCRIPTION
Resolves #132, adding the tagline to the readme.txt, giving Health Check control over what is displayed.