### PR TITLE
Give site status tests different runners

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -135,8 +135,6 @@ class Health_Check_Site_Status {
 		}
 
 		printf( '<span class="%1$s"></span> %2$s', esc_attr( $class ), esc_html( $text ) );
-
-		die(); // just in case.
 	}
 
 	/**
@@ -714,6 +712,77 @@ class Health_Check_Site_Status {
 			);
 		}
 	}
+
+	/**
+	 * Return a set of tests that belong to the site status page.
+	 *
+	 * Each site status test is defined here, they may be `direct` tests, that run on page load,
+	 * or `async` tests which will run later down the line via JavaScript calls to improve page
+	 * performance and hopefully also user experiences.
+	 *
+	 * @return array
+	 */
+	public static function get_tests() {
+		return array(
+			'direct' => array(
+				array(
+					'label' => __( 'WordPress Version', 'health-check' ),
+					'test'  => 'wordpress_version',
+				),
+				array(
+					'label' => __( 'Plugin Versions', 'health-check' ),
+					'test'  => 'plugin_version',
+				),
+				array(
+					'label' => __( 'Theme Versions', 'health-check' ),
+					'test'  => 'theme_version',
+				),
+				array(
+					'label' => __( 'PHP Version', 'health-check' ),
+					'test'  => 'php_version',
+				),
+				array(
+					'label' => __( 'Database Server version', 'health-check' ),
+					'test'  => 'sql_server',
+				),
+				array(
+					'label' => __( 'JSON Extension', 'health-check' ),
+					'test'  => 'json_extension',
+				),
+				array(
+					'label' => __( 'MySQL utf8mb4 support', 'health-check' ),
+					'test'  => 'utf8mb4_support',
+				),
+				array(
+					'label' => __( 'Communication with WordPress.org', 'health-check' ),
+					'test'  => 'dotorg_communication',
+				),
+				array(
+					'label' => __( 'HTTPS status', 'health-check' ),
+					'test'  => 'https_status',
+				),
+				array(
+					'label' => __( 'Secure communication', 'health-check' ),
+					'test'  => 'ssl_support',
+				),
+			),
+			'async'  => array(
+				array(
+					'label' => __( 'Scheduled events', 'health-check' ),
+					'test'  => 'scheduled_events',
+				),
+				array(
+					'label' => __( 'Background updates', 'health-check' ),
+					'test'  => 'background_updates',
+				),
+				array(
+					'label' => __( 'Loopback request', 'health-check' ),
+					'test'  => 'loopback_requests',
+				),
+			),
+		);
+	}
 }
 
-new Health_Check_Site_Status();
+global $health_check_site_status;
+$health_check_site_status = new Health_Check_Site_Status();

--- a/src/pages/site-status.php
+++ b/src/pages/site-status.php
@@ -9,6 +9,8 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'We\'re sorry, but you can not directly access this file.' );
 }
+
+global $health_check_site_status;
 ?>
 
 	<div class="notice notice-info inline">
@@ -19,98 +21,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<table class="widefat striped health-check-table">
 		<tbody>
+		<?php
+		$tests = Health_Check_Site_Status::get_tests();
+		foreach ( $tests['direct'] as $test ) :
+			?>
 			<tr>
-				<td><?php esc_html_e( 'WordPress Version', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="wordpress_version">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
+				<td><?php echo esc_html( $test['label'] ); ?></td>
+				<td class="" data-site-status="<?php echo esc_attr( $test['test'] ); ?>">
+					<?php
+					$test_function = sprintf(
+						'test_%s',
+						$test['test']
+					);
 
-			<tr>
-				<td><?php esc_html_e( 'Plugin Versions', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="plugin_version">
-					<span class="spinner is-active"></span>
+					if ( method_exists( $health_check_site_status, $test_function ) && is_callable( array( $health_check_site_status, $test_function ) ) ) {
+						call_user_func( array( $health_check_site_status, $test_function ) );
+					}
+					?>
 				</td>
 			</tr>
+		<?php endforeach; ?>
 
+		<?php foreach ( $tests['async'] as $test ) : ?>
 			<tr>
-				<td><?php esc_html_e( 'Theme Versions', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="theme_version">
+				<td><?php echo esc_html( $test['label'] ); ?></td>
+				<td class="health-check-site-status-test" data-site-status="<?php echo esc_attr( $test['test'] ); ?>">
 					<span class="spinner is-active"></span>
 				</td>
 			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'PHP Version', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="php_version">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td>
-					<?php esc_html_e( 'Database Server version', 'health-check' ); ?>
-				</td>
-				<td class="health-check-site-status-test" data-site-status="sql_server">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'JSON Extension', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="json_extension">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'MySQL utf8mb4 support', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="utf8mb4_support">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'Communication with WordPress.org', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="dotorg_communication">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'HTTPS status', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="https_status">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'Secure communication', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="ssl_support">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'Scheduled events', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="scheduled_events">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'Background updates', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="background_updates">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
-
-			<tr>
-				<td><?php esc_html_e( 'Loopback request', 'health-check' ); ?></td>
-				<td class="health-check-site-status-test" data-site-status="loopback_requests">
-					<span class="spinner is-active"></span>
-				</td>
-			</tr>
+		<?php endforeach; ?>
 		</tbody>
 	</table>
 


### PR DESCRIPTION
Site Status tests are sometimes slow, others are very fast and benefit from being rendered with the page load without impacting performance.

This PR holds the pre-requisite for both #181 and #122, as it moves the test declarations out of a flat file and into a callable function. It also separates tests based on directly callable (no impact), and asynchronously (high impact/slow) stacks of tests.

This allows them to be declared, but further enhancements should be discussed in #181 about which tests should run in which stack, and also to introduce a manner to run asynchronous tests manually instead of automatically as they are now.