### PR TITLE
[WIP] Add unit test for checking site status test execution time

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -754,10 +754,6 @@ class Health_Check_Site_Status {
 					'test'  => 'utf8mb4_support',
 				),
 				array(
-					'label' => __( 'Communication with WordPress.org', 'health-check' ),
-					'test'  => 'dotorg_communication',
-				),
-				array(
 					'label' => __( 'HTTPS status', 'health-check' ),
 					'test'  => 'https_status',
 				),
@@ -765,11 +761,15 @@ class Health_Check_Site_Status {
 					'label' => __( 'Secure communication', 'health-check' ),
 					'test'  => 'ssl_support',
 				),
-			),
-			'async'  => array(
 				array(
 					'label' => __( 'Scheduled events', 'health-check' ),
 					'test'  => 'scheduled_events',
+				),
+			),
+			'async'  => array(
+				array(
+					'label' => __( 'Communication with WordPress.org', 'health-check' ),
+					'test'  => 'dotorg_communication',
 				),
 				array(
 					'label' => __( 'Background updates', 'health-check' ),

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -18,7 +18,9 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 		);
 
 		$start_time = microtime( true );
+		ob_start();
 		call_user_func( array( $health_check_site_status, $func ) );
+		ob_end_clean();
 
 		return round( ( microtime( true ) - $start_time ) * 1000 );
 	}
@@ -34,15 +36,15 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 			$result = $this->runStatusTest( $test_function );
 
 			$message = sprintf(
-				'Func %s took too long',
+				'Function %s exceeded the execution time limit.',
 				$test_function
 			);
 
 			/**
-			 * Result should be <= 500 miliseconds.
+			 * Result should be <= 100 miliseconds.
 			 */
 			$this->assertLessThanOrEqual(
-				500,
+				100,
 				$result,
 				$message
 			);

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -1,6 +1,6 @@
 <?php
 
-class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
+class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 
 	private $tests_list;
 
@@ -25,9 +25,8 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 		return round( ( microtime( true ) - $start_time ) * 1000 );
 	}
 
-	public function testDirectTestsProf() {
-		$tests = $this->tests_list['direct'];
-
+	public function testSiteStatusDirectTests() {
+		$tests = $this->$tests_list['direct'];
 		foreach ( $tests as $test ) {
 			$test_function = sprintf(
 				'test_%s',
@@ -35,34 +34,19 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 			);
 
 			$result = $this->runStatusTest( $test_function );
+
+			$message = printf(
+				'Func %s took too long',
+				$test_function
+			);
 
 			/**
 			 * Result should be <= 100 miliseconds.
 			 */
 			$this->assertLessThanOrEqual(
 				100,
-				$result
-			);
-		}
-	}
-
-	public function testAsyncTestsProf() {
-		$tests = $this->tests_list['async'];
-
-		foreach ( $tests as $test ) {
-			$test_function = sprintf(
-				'test_%s',
-				$test['test']
-			);
-
-			$result = $this->runStatusTest( $test_function );
-
-			/**
-			 * Result should be > 100 miliseconds.
-			 */
-			$this->assertGreaterThan(
-				100,
-				$result
+				$result,
+				$message
 			);
 		}
 	}

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -35,7 +35,7 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 
 			$result = $this->runStatusTest( $test_function );
 
-			$message = printf(
+			$message = sprintf(
 				'Func %s took too long',
 				$test_function
 			);

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -26,7 +26,7 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 	}
 
 	public function testSiteStatusDirectTests() {
-		$tests = $this->$tests_list['direct'];
+		$tests = $this->tests_list['direct'];
 		foreach ( $tests as $test ) {
 			$test_function = sprintf(
 				'test_%s',

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -18,14 +18,12 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 		);
 
 		$start_time = microtime( true );
-		ob_start();
 		call_user_func( array( $health_check_site_status, $func ) );
-		ob_end_clean();
 
 		return round( ( microtime( true ) - $start_time ) * 1000 );
 	}
 
-	public function testSiteStatusDirectTests() {
+	public function testDirectTiming() {
 		$tests = $this->tests_list['direct'];
 		foreach ( $tests as $test ) {
 			$test_function = sprintf(
@@ -41,10 +39,10 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 			);
 
 			/**
-			 * Result should be <= 100 miliseconds.
+			 * Result should be <= 500 miliseconds.
 			 */
 			$this->assertLessThanOrEqual(
-				100,
+				500,
 				$result,
 				$message
 			);

--- a/tests/phpunit/test-tests-prof.php
+++ b/tests/phpunit/test-tests-prof.php
@@ -2,24 +2,24 @@
 
 class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 
-	private $health_check_site_status;
 	private $tests_list;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->$health_check_site_status = new Health_Check_Site_Status();
-		$this->$tests_list               = Health_Check_Site_Status::get_tests();
+		$this->$tests_list = Health_Check_Site_Status::get_tests();
 	}
 
 	private function runStatusTest( $func ) {
+		global $health_check_site_status;
+
 		$this->assertTrue(
-			method_exists( $this->$health_check_site_status, $func ) && is_callable( array( $this->$health_check_site_status, $func ) )
+			method_exists( $health_check_site_status, $func ) && is_callable( array( $health_check_site_status, $func ) )
 		);
 
 		$start_time = microtime( true );
 		ob_start();
-		call_user_func( array( $this->$health_check_site_status, $func ) );
+		call_user_func( array( $health_check_site_status, $func ) );
 		ob_end_clean();
 
 		return round( ( microtime( true ) - $start_time ) * 1000 );

--- a/tests/phpunit/test-tests-prof.php
+++ b/tests/phpunit/test-tests-prof.php
@@ -1,0 +1,69 @@
+<?php
+
+class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
+
+	private $health_check_site_status;
+	private $tests_list;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->$health_check_site_status = new Health_Check_Site_Status();
+		$this->$tests_list               = Health_Check_Site_Status::get_tests();
+	}
+
+	private function runTest( $func ) {
+		$this->assertTrue(
+			method_exists( $this->$health_check_site_status, $func ) && is_callable( array( $this->$health_check_site_status, $func ) )
+		);
+
+		$start_time = microtime( true );
+		ob_start();
+		call_user_func( array( $this->$health_check_site_status, $func ) );
+		ob_end_clean();
+
+		return round( ( microtime( true ) - $start_time ) * 1000 );
+	}
+
+	public function testDirectTestsProf() {
+		$tests = $this->$tests_list['direct'];
+
+		foreach ( $tests as $test ) {
+			$test_function = sprintf(
+				'test_%s',
+				$test['test']
+			);
+
+			$result = $this->runTest( $test_function );
+
+			/**
+			 * Result should be <= 100 miliseconds.
+			 */
+			$this->assertLessThanOrEqual(
+				100,
+				$result
+			);
+		}
+	}
+
+	public function testAsyncTestsProf() {
+		$tests = $this->$tests_list['async'];
+
+		foreach ( $tests as $test ) {
+			$test_function = sprintf(
+				'test_%s',
+				$test['test']
+			);
+
+			$result = $this->runTest( $test_function );
+
+			/**
+			 * Result should be >= 100 miliseconds.
+			 */
+			$this->assertGreaterThanOrEqual(
+				100,
+				$result
+			);
+		}
+	}
+}

--- a/tests/phpunit/test-tests-prof.php
+++ b/tests/phpunit/test-tests-prof.php
@@ -58,9 +58,9 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 			$result = $this->runTest( $test_function );
 
 			/**
-			 * Result should be >= 100 miliseconds.
+			 * Result should be > 100 miliseconds.
 			 */
-			$this->assertGreaterThanOrEqual(
+			$this->assertGreaterThan(
 				100,
 				$result
 			);

--- a/tests/phpunit/test-tests-prof.php
+++ b/tests/phpunit/test-tests-prof.php
@@ -12,7 +12,7 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 		$this->$tests_list               = Health_Check_Site_Status::get_tests();
 	}
 
-	private function runTest( $func ) {
+	private function runStatusTest( $func ) {
 		$this->assertTrue(
 			method_exists( $this->$health_check_site_status, $func ) && is_callable( array( $this->$health_check_site_status, $func ) )
 		);
@@ -34,7 +34,7 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 				$test['test']
 			);
 
-			$result = $this->runTest( $test_function );
+			$result = $this->runStatusTest( $test_function );
 
 			/**
 			 * Result should be <= 100 miliseconds.
@@ -55,7 +55,7 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 				$test['test']
 			);
 
-			$result = $this->runTest( $test_function );
+			$result = $this->runStatusTest( $test_function );
 
 			/**
 			 * Result should be > 100 miliseconds.

--- a/tests/phpunit/test-tests-prof.php
+++ b/tests/phpunit/test-tests-prof.php
@@ -2,7 +2,7 @@
 
 class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 
-	private $tests_list;
+	public $tests_list;
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/phpunit/test-tests-prof.php
+++ b/tests/phpunit/test-tests-prof.php
@@ -2,12 +2,12 @@
 
 class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 
-	public $tests_list;
+	private $tests_list;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->$tests_list = Health_Check_Site_Status::get_tests();
+		$this->tests_list = Health_Check_Site_Status::get_tests();
 	}
 
 	private function runStatusTest( $func ) {
@@ -26,7 +26,7 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 	}
 
 	public function testDirectTestsProf() {
-		$tests = $this->$tests_list['direct'];
+		$tests = $this->tests_list['direct'];
 
 		foreach ( $tests as $test ) {
 			$test_function = sprintf(
@@ -47,7 +47,7 @@ class Health_Check_Tests_Prof_Test extends WP_UnitTestCase {
 	}
 
 	public function testAsyncTestsProf() {
-		$tests = $this->$tests_list['async'];
+		$tests = $this->tests_list['async'];
 
 		foreach ( $tests as $test ) {
 			$test_function = sprintf(


### PR DESCRIPTION
These tests measure the execution time of the site status tests, checking that the direct tests take less than 100ms and the async tests take longer than 100ms.

This is a rough draft as I cannot run the tests locally yet.