### PR TITLE
WordPress 4.9 has compatibility fixes for PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - php: 7.2
       env: WP_HC_CS_TEST=yes
     - php: 7.2
-      env: WP_VERSION=4.0
+      env: WP_VERSION=4.9
     - php: 7.1
     - php: 7.1
       env: WP_VERSION=4.0


### PR DESCRIPTION
WordPress 4.9 introduced compatibility fixes for PHP 7.2 which are needed for tests to pass in the future.

This means that for PHP 7.2 and onward, we are changing the minimum WordPress version to 4.9 as well, this should be OK, as users on older versions of WP will need to update if they use more recent versions of PHP as well, so our test matrixes are still valid.