### PR TITLE
Added a unit test to check async site status tests take long than 100ms to execute

### DIFF
--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -60,7 +60,7 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 		);
 
 		foreach ( $tests as $test ) {
-			if ( in_array( $skip_testing, $test['test'] ) ) {
+			if ( in_array( $test['test'], $skip_testing ) ) {
 				continue;
 			}
 

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -53,7 +53,17 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 
 	public function testAsyncTiming() {
 		$tests = $this->tests_list['async'];
+
+		// Certain tests are known to be prolonged, but will appear short in testing
+		$skip_testing = array(
+			'loopback_requests',
+		);
+
 		foreach ( $tests as $test ) {
+			if ( in_array( $skip_testing, $test['test'] ) ) {
+				continue;
+			}
+
 			$test_function = sprintf(
 				'test_%s',
 				$test['test']

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -50,4 +50,31 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 			);
 		}
 	}
+
+	public function testAsyncTiming() {
+		$tests = $this->tests_list['async'];
+		foreach ( $tests as $test ) {
+			$test_function = sprintf(
+				'test_%s',
+				$test['test']
+			);
+
+			$result = $this->runStatusTest( $test_function );
+
+			$message = sprintf(
+				'Function %s executed in %dms and should be run directly.',
+				$test_function,
+				$result
+			);
+
+			/**
+			 * Result should be > 100 miliseconds.
+			 */
+			$this->assertGreaterThan(
+				100,
+				$result,
+				$message
+			);
+		}
+	}
 }


### PR DESCRIPTION
As discussed, added a unit test for the async site status tests.