### PR TITLE
Run async tests in succession

### DIFF
--- a/assets/javascript/site-status/site-status-tests.js
+++ b/assets/javascript/site-status/site-status-tests.js
@@ -1,18 +1,32 @@
 /* global ajaxurl */
 jQuery( document ).ready(function( $ ) {
-	$( '.health-check-site-status-test' ).each( function() {
-		var $check = $( this ),
-			data = {
-				action: 'health-check-site-status',
-				feature: $( this ).data( 'site-status' )
-			};
+	function run_next_site_status_test() {
+		var $test = $( '.health-check-site-status-test' ),
+			data;
+
+		// If there are no more tests to run, stop processing.
+		if ( $test.length < 1 ) {
+			return;
+		}
+
+		$test = $test.first();
+
+		data = {
+			action: 'health-check-site-status',
+			feature: $test.data( 'site-status' )
+		};
+
+		$test.removeClass( 'health-check-site-status-test' );
 
 		$.post(
 			ajaxurl,
 			data,
 			function( response ) {
-				$check.html( response );
+				$test.html( response );
+				run_next_site_status_test();
 			}
 		);
-	});
+	}
+
+	run_next_site_status_test();
 });


### PR DESCRIPTION
The final piece to #181, run the now async tests in succession.

There are relatively few async tests, it makes little sense to introduce UI elements to run them at this time, instead we'll let them run once the page is done loading, as before, and assess it based on feedback and potentially new tests.