### PR TITLE
Add REST API checks to the site status

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -777,7 +777,7 @@ class Health_Check_Site_Status {
 	 * @return array
 	 */
 	public static function get_tests() {
-		return array(
+		$tests = array(
 			'direct' => array(
 				array(
 					'label' => __( 'WordPress Version', 'health-check' ),
@@ -833,12 +833,18 @@ class Health_Check_Site_Status {
 					'label' => __( 'Loopback request', 'health-check' ),
 					'test'  => 'loopback_requests',
 				),
-				array(
-					'label' => __( 'REST API availability', 'health-check' ),
-					'test'  => 'rest_availability',
-				),
 			),
 		);
+
+		// Conditionally include REST rules if the function for it exists.
+		if ( function_exists( 'rest_url' ) ) {
+			$tests['direct'][] = array(
+				'label' => __( 'REST API availability', 'health-check' ),
+				'test'  => 'rest_availability',
+			);
+		}
+
+		return $tests;
 	}
 }
 

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -713,6 +713,60 @@ class Health_Check_Site_Status {
 		}
 	}
 
+	public function test_rest_availability() {
+		$cookies = wp_unslash( $_COOKIE );
+		$timeout = 10;
+		$headers = array(
+			'Cache-Control' => 'no-cache',
+		);
+
+		// Include Basic auth in loopback requests.
+		if ( isset( $_SERVER['PHP_AUTH_USER'] ) && isset( $_SERVER['PHP_AUTH_PW'] ) ) {
+			$headers['Authorization'] = 'Basic ' . base64_encode( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) . ':' . wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
+		}
+
+		$url = rest_url( 'wp/v2/posts' );
+
+		// We only need the first post to ensure this works, to make it low impact.
+		$url = add_query_arg( array(
+			'per_page' => 1,
+		), $url );
+
+		$r = wp_remote_get( $url, compact( 'cookies', 'headers', 'timeout' ) );
+
+		if ( is_wp_error( $r ) ) {
+			printf(
+				'<span class="error"></span> %s',
+				sprintf(
+					'%s<br>%s',
+					esc_html__( 'The REST API request failed due to an error.', 'health-check' ),
+					sprintf(
+						/* translators: %1$d: The HTTP response code. %2$s: The error message returned. */
+						esc_html__( 'Error encountered: (%1$d) %2$s', 'health-check' ),
+						wp_remote_retrieve_response_code( $r ),
+						$r->get_error_message()
+					)
+				)
+			);
+		} elseif ( 200 !== wp_remote_retrieve_response_code( $r ) ) {
+			printf(
+				'<span class="warning"></span> %s',
+				sprintf(
+					/* translators: %1$d: The HTTP response code returned. %2$s: The error message returned. */
+					esc_html__( 'The REST API call gave the following unexpected result: (%1$d) %2$s.', 'health-check' ),
+					wp_remote_retrieve_response_code( $r ),
+					wp_remote_retrieve_body( $r )
+				)
+			);
+		} else {
+
+			printf(
+				'<span class="good"></span> %s',
+				__( 'The REST API is available.', 'health-check' )
+			);
+		}
+	}
+
 	/**
 	 * Return a set of tests that belong to the site status page.
 	 *
@@ -778,6 +832,10 @@ class Health_Check_Site_Status {
 				array(
 					'label' => __( 'Loopback request', 'health-check' ),
 					'test'  => 'loopback_requests',
+				),
+				array(
+					'label' => __( 'REST API availability', 'health-check' ),
+					'test'  => 'rest_availability',
 				),
 			),
 		);

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -27,7 +27,17 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 
 	public function testDirectTiming() {
 		$tests = $this->tests_list['direct'];
+
+		// Certain tests may only appear slow in certain scenarios, although may appear long in testing
+		$skip_testing = array(
+			'rest_availability', // Runs slow on PHP 5.2, but in 5-10ms on other builds.
+		);
+
 		foreach ( $tests as $test ) {
+			if ( in_array( $test['test'], $skip_testing ) ) {
+				continue;
+			}
+
 			$test_function = sprintf(
 				'test_%s',
 				$test['test']
@@ -56,7 +66,7 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 
 		// Certain tests are known to be prolonged, but will appear short in testing
 		$skip_testing = array(
-			'loopback_requests',
+			'loopback_requests', // fail early, as there's no loopback to hit on a unit test.
 		);
 
 		foreach ( $tests as $test ) {


### PR DESCRIPTION
The REST API which comes built in on all WordPress installs these days is becoming more and more instrumental. With WordPress 5.0 requiring its existence and functionality to edit content.

Many sites have security plugins, custom access rules, host access rules, CDN providers, mod_security, and a whole other slew of unknown variables that may play in here.

Knowing that you, as a user, can retrieve data from the API will be instrumental moving forward.

This PR addresses this, by adding a new Site Status check that will attempt to fetch the most recent post entry from the API on an endpoint that should always exist `wp/v2/posts`, and any failures will provide a status code and the body of the response to help any support user figure out what is preventing access.