### PR TITLE
Add Plugin/Theme update checks to the site status tests

### DIFF
--- a/src/health-check.php
+++ b/src/health-check.php
@@ -59,6 +59,7 @@ require_once( dirname( __FILE__ ) . '/includes/class-health-check-troubleshoot.p
 require_once( dirname( __FILE__ ) . '/includes/class-health-check-files-integrity.php' );
 require_once( dirname( __FILE__ ) . '/includes/class-health-check-mail-check.php' );
 require_once( dirname( __FILE__ ) . '/includes/class-health-check-site-status.php' );
+require_once( dirname( __FILE__ ) . '/includes/class-health-check-updates.php' );
 
 // Initialize our plugin.
 new Health_Check();

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -696,6 +696,23 @@ class Health_Check_Site_Status {
 		echo '</ul>';
 	}
 
+	public function test_extension_updates() {
+		$updates = new Health_Check_Updates();
+		$tests   = $updates->run_tests();
+
+		echo '<ul>';
+
+		foreach ( $tests as $test ) {
+			printf(
+				'<li><span class="%s"></span> %s</li>',
+				esc_attr( $test->severity ),
+				$test->desc
+			);
+		}
+
+		echo '</ul>';
+	}
+
 	public function test_loopback_requests() {
 		$check_loopback = Health_Check_Loopback::can_perform_loopback();
 
@@ -764,6 +781,10 @@ class Health_Check_Site_Status {
 				array(
 					'label' => __( 'Scheduled events', 'health-check' ),
 					'test'  => 'scheduled_events',
+				),
+				array(
+					'label' => __( 'Plugin and Theme Updates', 'health-check' ),
+					'test'  => 'extension_updates',
 				),
 			),
 			'async'  => array(

--- a/src/includes/class-health-check-updates.php
+++ b/src/includes/class-health-check-updates.php
@@ -1,0 +1,562 @@
+<?php
+/**
+ * Class for testing plugin/theme updates in the WordPress code.
+ *
+ * @package Health Check
+ */
+
+/**
+ * Class Health_Check_Updates
+ */
+class Health_Check_Updates {
+	private $plugins_before;
+	private $plugins_after;
+	private static $plugins_blocked;
+	private $themes_before;
+	private $themes_after;
+	private static $themes_blocked;
+
+	/**
+	 * Health_Check_Updates constructor.
+	 *
+	 * @uses Health_Check_Updates::init()
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initiate the plugin class.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->plugins_before  = (array) array();
+		$this->plugins_after   = (array) array();
+		self::$plugins_blocked = (bool) false;
+
+		$this->themes_before  = (array) array();
+		$this->themes_after   = (array) array();
+		self::$themes_blocked = (bool) false;
+	}
+
+	/**
+	 * Run tests to determine if auto-updates can run.
+	 *
+	 * @uses get_class_methods()
+	 * @uses substr()
+	 * @uses call_user_func()
+	 *
+	 * @return array
+	 */
+	public function run_tests() {
+		$tests = array();
+
+		foreach ( get_class_methods( $this ) as $method ) {
+			if ( 'test_' !== substr( $method, 0, 5 ) ) {
+				continue;
+			}
+
+			$result = call_user_func( array( $this, $method ) );
+
+			if ( false === $result || null === $result ) {
+				continue;
+			}
+
+			$result = (object) $result;
+
+			if ( empty( $result->severity ) ) {
+				$result->severity = 'warning';
+			}
+
+			$tests[ $method ] = $result;
+		}
+
+		return $tests;
+	}
+
+	/**
+	 * Check if plugin updates have been tampered with.
+	 *
+	 * @uses Health_Check_Updates::check_plugin_update_hooks()
+	 * @uses esc_html__()
+	 * @uses Health_Check_Updates::check_plugin_update_pre_request()
+	 * @uses Health_Check_Updates::check_plugin_update_request_args()
+	 *
+	 * @return array
+	 */
+	function test_plugin_updates() {
+		// Check if any update hooks have been removed.
+		$hooks = $this->check_plugin_update_hooks();
+		if ( ! $hooks ) {
+			return array(
+				'desc'     => esc_html__( 'Plugin update hooks have been removed.', 'health-check' ),
+				'severity' => 'fail',
+			);
+		}
+
+		// Check if update requests are being blocked.
+		$blocked = $this->check_plugin_update_pre_request();
+		if ( true === $blocked ) {
+			return array(
+				'desc'     => esc_html__( 'Plugin update requests have been blocked.', 'health-check' ),
+				'severity' => 'fail',
+			);
+		}
+
+		// Check if plugins have been removed from the update requests.
+		$diff = (array) $this->check_plugin_update_request_args();
+		if ( 0 !== count( $diff ) ) {
+			return array(
+				'desc'     => sprintf(
+					/* translators: %s: List of plugin names. */
+					esc_html__( 'The following Plugins have been removed from update checks: %s.', 'health-check' ),
+					implode( ',', $diff )
+				),
+				'severity' => 'warning',
+			);
+		}
+
+		return array(
+			'desc'     => esc_html__( 'Plugin updates should be working as expected.', 'health-check' ),
+			'severity' => 'pass',
+		);
+	}
+
+	/**
+	 * Check if any plugin update hooks have been removed.
+	 *
+	 * @uses has_filter()
+	 * @uses wp_next_scheduled()
+	 *
+	 * @return array
+	 */
+	function check_plugin_update_hooks() {
+		$test1 = has_filter( 'load-plugins.php', 'wp_update_plugins' );
+		$test2 = has_filter( 'load-update.php', 'wp_update_plugins' );
+		$test3 = has_filter( 'load-update-core.php', 'wp_update_plugins' );
+		$test4 = has_filter( 'wp_update_plugins', 'wp_update_plugins' );
+		$test5 = has_filter( 'admin_init', '_maybe_update_plugins' );
+		$test6 = wp_next_scheduled( 'wp_update_plugins' );
+
+		return $test1 && $test2 && $test3 && $test4 && $test5 && $test6;
+	}
+
+	/**
+	 * Check if plugin update request checks are being tampered with at the 'pre_http_request' filter.
+	 *
+	 * @uses add_action()
+	 * @uses Health_Check_Updates::wp_plugin_update_fake_request()
+	 * @uses esc_html__()
+	 *
+	 * @return array
+	 */
+	function check_plugin_update_pre_request() {
+		add_action( 'pre_http_request', array( $this, 'plugin_pre_request_check' ), PHP_INT_MAX, 3 );
+		add_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX, 3 );
+
+		$this->plugin_update_fake_request();
+
+		remove_action( 'pre_http_request', array( $this, 'plugin_pre_request_check' ), PHP_INT_MAX );
+		remove_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX );
+
+		return self::$plugins_blocked;
+	}
+
+	/**
+	 * Check plugin update requests to see if they are being blocked.
+	 *
+	 * @param  bool $pre If not false, request cancelled.
+	 * @param  array $r Request parameters.
+	 * @param  string $url Request URL.
+	 * @return bool
+	 */
+	function plugin_pre_request_check( $pre, $r, $url ) {
+		$check_url = 'api.wordpress.org/plugins/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $pre; // Not a plugin update request.
+		}
+
+		// If not false something is blocking update checks
+		if ( false !== $pre ) {
+			self::$plugins_blocked = (bool) true;
+		}
+
+		return $pre;
+	}
+
+	/**
+	 * Check if plugins are being removed at the 'http_request_args' filter.
+	 *
+	 * @uses add_action()
+	 * @uses Health_Check_Updates::wp_plugin_update_fake_request()
+	 * @uses remove_action()
+	 *
+	 * @return array
+	 */
+	function check_plugin_update_request_args() {
+		add_action( 'http_request_args', array( $this, 'plugin_request_args_before' ), 1, 2 );
+		add_action( 'http_request_args', array( $this, 'plugin_request_args_after' ), PHP_INT_MAX, 2 );
+		add_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX, 3 );
+
+		$this->plugin_update_fake_request();
+
+		remove_action( 'http_request_args', array( $this, 'plugin_request_args_before' ), 1 );
+		remove_action( 'http_request_args', array( $this, 'plugin_request_args_after' ), PHP_INT_MAX );
+		remove_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX );
+
+		$diff = array_diff_key( $this->plugins_before['plugins'], $this->plugins_after['plugins'] );
+
+		$titles = array();
+		foreach ( $diff as $item ) {
+			$titles[] = $item['Title'];
+		}
+
+		return $titles;
+	}
+
+	/**
+	 * Record the list of plugins from plugin update requests at the start of filtering.
+	 *
+	 * @param  array $r Request parameters.
+	 * @param  string $url Request URL.
+	 * @return array
+	 */
+	function plugin_request_args_before( $r, $url ) {
+		$check_url = 'api.wordpress.org/plugins/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $r; // Not a plugin update request.
+		}
+
+		$this->plugins_before = (array) json_decode( $r['body']['plugins'], true );
+
+		return $r;
+	}
+
+	/**
+	 * Record the list of plugins from plugin update requests at the end of filtering.
+	 *
+	 * @param  array $r Request parameters.
+	 * @param  string $url Request URL.
+	 * @return array
+	 */
+	function plugin_request_args_after( $r, $url ) {
+		$check_url = 'api.wordpress.org/plugins/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $r; // Not a plugin update request.
+		}
+
+		$this->plugins_after = (array) json_decode( $r['body']['plugins'], true );
+
+		return $r;
+	}
+
+	/**
+	 * Create and trigger a fake plugin update check request.
+	 *
+	 * @uses get_plugins()
+	 * @uses get_option()
+	 * @uses wp_get_installed_translations()
+	 * @uses apply_filters()
+	 * @uses wp_json_encode()
+	 * @uses get_bloginfo()
+	 * @uses home_url()
+	 * @uses wp_http_supports()
+	 * @uses set_url_scheme()
+	 * @uses wp_remote_post()
+	 *
+	 * @return void
+	 */
+	function plugin_update_fake_request() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
+
+		// Prepare data for the request.
+		$plugins      = get_plugins();
+		$active       = get_option( 'active_plugins', array() );
+		$to_send      = compact( 'plugins', 'active' );
+		$translations = wp_get_installed_translations( 'plugins' );
+		$locales      = array_values( get_available_languages() );
+		$locales      = (array) apply_filters( 'plugins_update_check_locales', $locales );
+		$locales      = array_unique( $locales );
+		$timeout      = 3 + (int) ( count( $plugins ) / 10 );
+
+		// Setup the request options.
+		$options = array(
+			'timeout'    => $timeout,
+			'body'       => array(
+				'plugins'      => wp_json_encode( $to_send ),
+				'translations' => wp_json_encode( $translations ),
+				'locale'       => wp_json_encode( $locales ),
+				'all'          => wp_json_encode( true ),
+			),
+			'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
+		);
+
+		// Set the URL
+		$http_url = 'http://api.wordpress.org/plugins/update-check/1.1/';
+		$url      = wp_http_supports( array( 'ssl' ) ) ? set_url_scheme( $http_url, 'https' ) : $http_url;
+
+		// Ignore the response. Just need the hooks to fire.
+		wp_remote_post( $url, $options );
+	}
+
+	/**
+	 * Check if theme updates have been tampered with.
+	 *
+	 * @uses Health_Check_Updates::check_theme_update_hooks()
+	 * @uses esc_html__()
+	 * @uses Health_Check_Updates::check_theme_update_pre_request()
+	 * @uses Health_Check_Updates::check_theme_update_request_args()
+	 *
+	 * @return array
+	 */
+	function test_constant_theme_updates() {
+		// Check if any update hooks have been removed.
+		$hooks = $this->check_theme_update_hooks();
+		if ( ! $hooks ) {
+			return array(
+				'desc'     => esc_html__( 'Theme update hooks have been removed.', 'health-check' ),
+				'severity' => 'fail',
+			);
+		}
+
+		// Check if update requests are being blocked.
+		$blocked = $this->check_theme_update_pre_request();
+		if ( true === $blocked ) {
+			return array(
+				'desc'     => esc_html__( 'Theme update requests have been blocked.', 'health-check' ),
+				'severity' => 'fail',
+			);
+		}
+
+		// Check if themes have been removed from the update requests.
+		$diff = (array) $this->check_theme_update_request_args();
+		if ( 0 !== count( $diff ) ) {
+			return array(
+				'desc'     => sprintf(
+					/* translators: %s: List of theme names. */
+					esc_html__( 'The following Themes have been removed from update checks: %s.', 'health-check' ),
+					implode( ',', $diff )
+				),
+				'severity' => 'warning',
+			);
+		}
+
+		return array(
+			'desc'     => esc_html__( 'Theme updates should be working as expected.', 'health-check' ),
+			'severity' => 'pass',
+		);
+	}
+
+	/**
+	 * Check if any theme update hooks have been removed.
+	 *
+	 * @uses has_filter()
+	 * @uses wp_next_scheduled()
+	 *
+	 * @return array
+	 */
+	function check_theme_update_hooks() {
+		$test1 = has_filter( 'load-themes.php', 'wp_update_themes' );
+		$test2 = has_filter( 'load-update.php', 'wp_update_themes' );
+		$test3 = has_filter( 'load-update-core.php', 'wp_update_themes' );
+		$test4 = has_filter( 'wp_update_themes', 'wp_update_themes' );
+		$test5 = has_filter( 'admin_init', '_maybe_update_themes' );
+		$test6 = wp_next_scheduled( 'wp_update_themes' );
+
+		return $test1 && $test2 && $test3 && $test4 && $test5 && $test6;
+	}
+
+	/**
+	 * Check if theme update request checks are being tampered with at the 'pre_http_request' filter.
+	 *
+	 * @uses add_action()
+	 * @uses Health_Check_Updates::wp_theme_update_fake_request()
+	 * @uses esc_html__()
+	 *
+	 * @return array
+	 */
+	function check_theme_update_pre_request() {
+		add_action( 'pre_http_request', array( $this, 'theme_pre_request_check' ), PHP_INT_MAX, 3 );
+		add_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX, 3 );
+
+		$this->theme_update_fake_request();
+
+		remove_action( 'pre_http_request', array( $this, 'theme_pre_request_check' ), PHP_INT_MAX );
+		remove_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX );
+
+		return self::$themes_blocked;
+	}
+
+	/**
+	 * Check theme update requests to see if they are being blocked.
+	 *
+	 * @param  bool $pre If not false, request cancelled.
+	 * @param  array $r Request parameters.
+	 * @param  string $url Request URL.
+	 * @return bool
+	 */
+	function theme_pre_request_check( $pre, $r, $url ) {
+		$check_url = 'api.wordpress.org/themes/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $pre; // Not a theme update request.
+		}
+
+		// If not false something is blocking update checks
+		if ( false !== $pre ) {
+			self::$themes_blocked = (bool) true;
+		}
+
+		return $pre;
+	}
+
+	/**
+	 * Check if themes are being removed at the 'http_request_args' filter.
+	 *
+	 * @uses add_action()
+	 * @uses Health_Check_Updates::wp_theme_update_fake_request()
+	 * @uses remove_action()
+	 *
+	 * @return array
+	 */
+	function check_theme_update_request_args() {
+		add_action( 'http_request_args', array( $this, 'theme_request_args_before' ), 1, 2 );
+		add_action( 'http_request_args', array( $this, 'theme_request_args_after' ), PHP_INT_MAX, 2 );
+		add_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX, 3 );
+
+		$this->theme_update_fake_request();
+
+		remove_action( 'http_request_args', array( $this, 'theme_request_args_before' ), 1 );
+		remove_action( 'http_request_args', array( $this, 'theme_request_args_after' ), PHP_INT_MAX );
+		remove_action( 'pre_http_request', array( $this, 'block_fake_request' ), PHP_INT_MAX );
+
+		$diff = array_diff_key( $this->themes_before['themes'], $this->themes_after['themes'] );
+
+		$titles = array();
+		foreach ( $diff as $item ) {
+			$titles[] = $item['Title'];
+		}
+
+		return $titles;
+	}
+
+	/**
+	 * Record the list of themes from theme update requests at the start of filtering.
+	 *
+	 * @param  array $r Request parameters.
+	 * @param  string $url Request URL.
+	 * @return array
+	 */
+	function theme_request_args_before( $r, $url ) {
+		$check_url = 'api.wordpress.org/themes/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $r; // Not a theme update request.
+		}
+
+		$this->themes_before = (array) json_decode( $r['body']['themes'], true );
+
+		return $r;
+	}
+
+	/**
+	 * Record the list of themes from theme update requests at the end of filtering.
+	 *
+	 * @param  array $r Request parameters.
+	 * @param  string $url Request URL.
+	 * @return array
+	 */
+	function theme_request_args_after( $r, $url ) {
+		$check_url = 'api.wordpress.org/themes/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $r; // Not a theme update request.
+		}
+
+		$this->themes_after = (array) json_decode( $r['body']['themes'], true );
+
+		return $r;
+	}
+
+	/**
+	 * Create and trigger a fake theme update check request.
+	 *
+	 * @uses wp_get_themes()
+	 * @uses wp_get_installed_translations()
+	 * @uses get_option()
+	 * @uses get_available_languages()
+	 * @uses wp_json_encode()
+	 * @uses get_bloginfo()
+	 * @uses home_url()
+	 * @uses wp_http_supports()
+	 * @uses set_url_scheme()
+	 * @uses wp_remote_post()
+	 *
+	 * @return void
+	 */
+	function theme_update_fake_request() {
+		$themes            = array();
+		$checked           = array();
+		$request           = array();
+		$installed_themes  = wp_get_themes();
+		$translations      = wp_get_installed_translations( 'themes' );
+		$request['active'] = get_option( 'stylesheet' );
+
+		foreach ( $installed_themes as $theme ) {
+			$checked[ $theme->get_stylesheet() ] = $theme->get( 'Version' );
+
+			$themes[ $theme->get_stylesheet() ] = array(
+				'Name'       => $theme->get( 'Name' ),
+				'Title'      => $theme->get( 'Name' ),
+				'Version'    => $theme->get( 'Version' ),
+				'Author'     => $theme->get( 'Author' ),
+				'Author URI' => $theme->get( 'AuthorURI' ),
+				'Template'   => $theme->get_template(),
+				'Stylesheet' => $theme->get_stylesheet(),
+			);
+		}
+
+		$request['themes'] = $themes;
+
+		$locales = array_values( get_available_languages() );
+		$timeout = 3 + (int) ( count( $themes ) / 10 );
+
+		$options = array(
+			'timeout'    => $timeout,
+			'body'       => array(
+				'themes'       => wp_json_encode( $request ),
+				'translations' => wp_json_encode( $translations ),
+				'locale'       => wp_json_encode( $locales ),
+			),
+			'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
+		);
+
+		// Set the URL
+		$http_url = 'http://api.wordpress.org/themes/update-check/1.1/';
+		$url      = wp_http_supports( array( 'ssl' ) ) ? set_url_scheme( $http_url, 'https' ) : $http_url;
+
+		// Ignore the response. Just need the hooks to fire.
+		wp_remote_post( $url, $options );
+	}
+
+	/**
+	 * Blocks the fake update requests, ensuring they do not slow down page loads.
+	 *
+	 * @param  bool $pre If not false, request cancelled.
+	 * @param  array $r Request parameters.
+	 * @param  string $url Request URL.
+	 * @return bool
+	 */
+	function block_fake_request( $pre, $r, $url ) {
+		switch ( $url ) {
+			case 'https://api.wordpress.org/plugins/update-check/1.1/':
+				return 'block_request';
+			case 'https://api.wordpress.org/themes/update-check/1.1/':
+				return 'block_request';
+			default:
+				return $pre;
+		}
+	}
+}

--- a/src/includes/class-health-check-updates.php
+++ b/src/includes/class-health-check-updates.php
@@ -470,6 +470,8 @@ class Health_Check_Updates {
 			return $r; // Not a theme update request.
 		}
 
+		print_r( json_decode( $r['body']['themes'], true )['themes'] );
+
 		$this->themes_before = (array) json_decode( $r['body']['themes'], true );
 
 		return $r;

--- a/src/includes/class-health-check-updates.php
+++ b/src/includes/class-health-check-updates.php
@@ -285,16 +285,29 @@ class Health_Check_Updates {
 		$timeout      = 3 + (int) ( count( $plugins ) / 10 );
 
 		// Setup the request options.
-		$options = array(
-			'timeout'    => $timeout,
-			'body'       => array(
-				'plugins'      => wp_json_encode( $to_send ),
-				'translations' => wp_json_encode( $translations ),
-				'locale'       => wp_json_encode( $locales ),
-				'all'          => wp_json_encode( true ),
-			),
-			'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
-		);
+		if ( function_exists( 'wp_json_encode' ) ) {
+			$options = array(
+				'timeout'    => $timeout,
+				'body'       => array(
+					'plugins'      => wp_json_encode( $to_send ),
+					'translations' => wp_json_encode( $translations ),
+					'locale'       => wp_json_encode( $locales ),
+					'all'          => wp_json_encode( true ),
+				),
+				'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
+			);
+		} else {
+			$options = array(
+				'timeout'    => $timeout,
+				'body'       => array(
+					'plugins'      => json_encode( $to_send ),
+					'translations' => json_encode( $translations ),
+					'locale'       => json_encode( $locales ),
+					'all'          => json_encode( true ),
+				),
+				'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
+			);
+		}
 
 		// Set the URL
 		$http_url = 'http://api.wordpress.org/plugins/update-check/1.1/';
@@ -523,15 +536,27 @@ class Health_Check_Updates {
 		$locales = array_values( get_available_languages() );
 		$timeout = 3 + (int) ( count( $themes ) / 10 );
 
-		$options = array(
-			'timeout'    => $timeout,
-			'body'       => array(
-				'themes'       => wp_json_encode( $request ),
-				'translations' => wp_json_encode( $translations ),
-				'locale'       => wp_json_encode( $locales ),
-			),
-			'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
-		);
+		if ( function_exists( 'wp_json_encode' ) ) {
+			$options = array(
+				'timeout'    => $timeout,
+				'body'       => array(
+					'themes'       => wp_json_encode( $request ),
+					'translations' => wp_json_encode( $translations ),
+					'locale'       => wp_json_encode( $locales ),
+				),
+				'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
+			);
+		} else {
+			$options = array(
+				'timeout'    => $timeout,
+				'body'       => array(
+					'themes'       => json_encode( $request ),
+					'translations' => json_encode( $translations ),
+					'locale'       => json_encode( $locales ),
+				),
+				'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . home_url( '/' ),
+			);
+		}
 
 		// Set the URL
 		$http_url = 'http://api.wordpress.org/themes/update-check/1.1/';

--- a/src/includes/class-health-check-updates.php
+++ b/src/includes/class-health-check-updates.php
@@ -470,8 +470,6 @@ class Health_Check_Updates {
 			return $r; // Not a theme update request.
 		}
 
-		print_r( json_decode( $r['body']['themes'], true )['themes'] );
-
 		$this->themes_before = (array) json_decode( $r['body']['themes'], true );
 
 		return $r;

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -88,7 +88,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 			return $r; // Not a plugin update request.
 		}
 
-		$plugins = json_decode( $r['body']['plugins'] );
+		$plugins = json_decode( $r['body']['plugins'], true );
 		unset( $plugins->plugins['akismet/akismet.php'] );
 		unset( $plugins->active['akismet/akismet.php'] );
 		$r['body']['plugins'] = json_encode( $plugins );
@@ -101,7 +101,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 			return $r; // Not a theme update request.
 		}
 
-		$themes = json_decode( $r['body']['themes'] );
+		$themes = json_decode( $r['body']['themes'], true );
 		unset( $themes[ get_option( 'template' ) ] );
 		unset( $themes[ get_option( 'stylesheet' ) ] );
 		$r['body']['themes'] = json_encode( $themes );

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -89,8 +89,8 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		}
 
 		$plugins = json_decode( $r['body']['plugins'], true );
-		unset( $plugins->plugins['akismet/akismet.php'] );
-		unset( $plugins->active['akismet/akismet.php'] );
+		unset( $plugins['plugins']['akismet/akismet.php'] );
+		unset( $plugins['active']['akismet/akismet.php'] );
 		$r['body']['plugins'] = json_encode( $plugins );
 		return $r;
 	}

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -82,7 +82,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		$this->assertCount( 1, $diff );
 	}
 
-	private function hidePlugin( $r, $url ) {
+	public function hidePlugin( $r, $url ) {
 		$check_url = 'api.wordpress.org/plugins/update-check/1.1/';
 		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
 			return $r; // Not a plugin update request.
@@ -95,7 +95,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		return $r;
 	}
 
-	private function hideTheme( $r, $url ) {
+	public function hideTheme( $r, $url ) {
 		$check_url = 'api.wordpress.org/themes/update-check/1.1/';
 		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
 			return $r; // Not a theme update request.
@@ -108,7 +108,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		return $r;
 	}
 
-	private function blockUpdates( $pre, $r, $url ) {
+	public function blockUpdates( $pre, $r, $url ) {
 		switch ( $url ) {
 			case 'https://api.wordpress.org/plugins/update-check/1.1/':
 				return 'block_request';

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -26,7 +26,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 
 	public function testPluginUpdateRequestArgs() {
 		// Check if plugins have been removed from the update requests.
-		$diff = (array) $this->check_plugin_update_request_args();
+		$diff = (array) $this->test_updates->check_plugin_update_request_args();
 
 		$this->assertCount( 0, $diff );
 	}
@@ -47,7 +47,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 
 	public function testThemeUpdateRequestArgs() {
 		// Check if themes have been removed from the update requests.
-		$diff = (array) $this->check_theme_update_request_args();
+		$diff = (array) $this->test_updates->check_theme_update_request_args();
 
 		$this->assertCount( 0, $diff );
 	}

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -88,10 +88,10 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 			return $r; // Not a plugin update request.
 		}
 
-		$plugins = unserialize( $r['body']['plugins'] );
+		$plugins = json_decode( $r['body']['plugins'] );
 		unset( $plugins->plugins['akismet/akismet.php'] );
 		unset( $plugins->active['akismet/akismet.php'] );
-		$r['body']['plugins'] = serialize( $plugins );
+		$r['body']['plugins'] = json_encode( $plugins );
 		return $r;
 	}
 
@@ -101,10 +101,10 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 			return $r; // Not a theme update request.
 		}
 
-		$themes = unserialize( $r['body']['themes'] );
+		$themes = json_decode( $r['body']['themes'] );
 		unset( $themes[ get_option( 'template' ) ] );
 		unset( $themes[ get_option( 'stylesheet' ) ] );
-		$r['body']['themes'] = serialize( $themes );
+		$r['body']['themes'] = json_encode( $themes );
 		return $r;
 	}
 

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -28,7 +28,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		$this->assertFalse( $blocked );
 
 		// Check detection of blocked update requests.
-		add_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
+		add_action( 'pre_http_request', array( $this, 'blockUpdates' ), 10, 3 );
 		$blocked = $this->test_updates->check_plugin_update_pre_request();
 		$this->assertTrue( $blocked );
 		remove_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
@@ -40,7 +40,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		$this->assertCount( 0, $diff );
 
 		// Check for plugin which has been hidden.
-		add_filter( 'http_request_args', array( $this, 'hidePlugin' ) );
+		add_filter( 'http_request_args', array( $this, 'hidePlugin' ), 10, 2 );
 		$diff = (array) $this->test_updates->check_plugin_update_request_args();
 		remove_filter( 'http_request_args', array( $this, 'hidePlugin' ) );
 		$this->assertCount( 1, $diff );
@@ -64,7 +64,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		$this->assertFalse( $blocked );
 
 		// Check detection of blocked update requests.
-		add_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
+		add_action( 'pre_http_request', array( $this, 'blockUpdates' ), 10, 3 );
 		$blocked = $this->test_updates->check_theme_update_pre_request();
 		$this->assertTrue( $blocked );
 		remove_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
@@ -76,7 +76,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		$this->assertCount( 0, $diff );
 
 		// Check for theme which has been hidden.
-		add_filter( 'http_request_args', array( $this, 'hideTheme' ) );
+		add_filter( 'http_request_args', array( $this, 'hideTheme' ), 10, 2 );
 		$diff = (array) $this->test_updates->check_theme_update_request_args();
 		remove_filter( 'http_request_args', array( $this, 'hideTheme' ) );
 		$this->assertCount( 1, $diff );

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -102,7 +102,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		}
 
 		$themes = json_decode( $r['body']['themes'], true );
-		unset( $themes['twentyseventeen'] );
+		unset( $themes['themes']['twentyseventeen'] );
 		$r['body']['themes'] = json_encode( $themes );
 		return $r;
 	}

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -102,6 +102,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		}
 
 		$themes = json_decode( $r['body']['themes'], true );
+		unset( $themes['themes']['twentyfourteen'] );
 		unset( $themes['themes']['twentyseventeen'] );
 		$r['body']['themes'] = json_encode( $themes );
 		return $r;

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -102,8 +102,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 		}
 
 		$themes = json_decode( $r['body']['themes'], true );
-		unset( $themes[ get_option( 'template' ) ] );
-		unset( $themes[ get_option( 'stylesheet' ) ] );
+		unset( $themes['twentyseventeen'] );
 		$r['body']['themes'] = json_encode( $themes );
 		return $r;
 	}

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -11,44 +11,112 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 	}
 
 	public function testPluginHooks() {
-		// Check if any update hooks have been removed.
+		// Check update hooks are in place.
 		$hooks = $this->test_updates->check_plugin_update_hooks();
-
 		$this->assertTrue( $hooks );
+
+		// Check update hooks have been removed.
+		remove_filter( 'load-plugins.php', 'wp_update_plugins' );
+		$hooks = $this->test_updates->check_plugin_update_hooks();
+		add_filter( 'load-plugins.php', 'wp_update_plugins' );
+		$this->assertFalse( $hooks );
 	}
 
 	public function testPluginUpdateRequest() {
 		// Check if update requests are being blocked.
 		$blocked = $this->test_updates->check_plugin_update_pre_request();
-
 		$this->assertFalse( $blocked );
+
+		// Check detection of blocked update requests.
+		add_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
+		$blocked = $this->test_updates->check_plugin_update_pre_request();
+		$this->assertTrue( $blocked );
+		remove_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
 	}
 
 	public function testPluginUpdateRequestArgs() {
 		// Check if plugins have been removed from the update requests.
 		$diff = (array) $this->test_updates->check_plugin_update_request_args();
-
 		$this->assertCount( 0, $diff );
+
+		// Check for plugin which has been hidden.
+		add_filter( 'http_request_args', array( $this, 'hidePlugin' ) );
+		$diff = (array) $this->test_updates->check_plugin_update_request_args();
+		remove_filter( 'http_request_args', array( $this, 'hidePlugin' ) );
+		$this->assertCount( 1, $diff );
 	}
 
 	public function testThemeHooks() {
-		// Check if any update hooks have been removed.
+		// Check if update hooks are in place.
 		$hooks = $this->test_updates->check_theme_update_hooks();
-
 		$this->assertTrue( $hooks );
+
+		// Check update hooks have been removed.
+		remove_filter( 'load-themes.php', 'wp_update_themes' );
+		$hooks = $this->test_updates->check_plugin_update_hooks();
+		add_filter( 'load-themes.php', 'wp_update_themes' );
+		$this->assertFalse( $hooks );
 	}
 
 	public function testThemeUpdateRequest() {
 		// Check if update requests are being blocked.
 		$blocked = $this->test_updates->check_theme_update_pre_request();
-
 		$this->assertFalse( $blocked );
+
+		// Check detection of blocked update requests.
+		add_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
+		$blocked = $this->test_updates->check_theme_update_pre_request();
+		$this->assertTrue( $blocked );
+		remove_action( 'pre_http_request', array( $this, 'blockUpdates' ) );
 	}
 
 	public function testThemeUpdateRequestArgs() {
 		// Check if themes have been removed from the update requests.
 		$diff = (array) $this->test_updates->check_theme_update_request_args();
-
 		$this->assertCount( 0, $diff );
+
+		// Check for theme which has been hidden.
+		add_filter( 'http_request_args', array( $this, 'hideTheme' ) );
+		$diff = (array) $this->test_updates->check_theme_update_request_args();
+		remove_filter( 'http_request_args', array( $this, 'hideTheme' ) );
+		$this->assertCount( 1, $diff );
 	}
+
+	private function hidePlugin( $r, $url ) {
+		$check_url = 'api.wordpress.org/plugins/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $r; // Not a plugin update request.
+		}
+
+		$plugins = unserialize( $r['body']['plugins'] );
+		unset( $plugins->plugins['akismet/akismet.php'] );
+		unset( $plugins->active['akismet/akismet.php'] );
+		$r['body']['plugins'] = serialize( $plugins );
+		return $r;
+	}
+
+	private function hideTheme( $r, $url ) {
+		$check_url = 'api.wordpress.org/themes/update-check/1.1/';
+		if ( 0 !== substr_compare( $url, $check_url, -strlen( $check_url ) ) ) {
+			return $r; // Not a theme update request.
+		}
+
+		$themes = unserialize( $r['body']['themes'] );
+		unset( $themes[ get_option( 'template' ) ] );
+		unset( $themes[ get_option( 'stylesheet' ) ] );
+		$r['body']['themes'] = serialize( $themes );
+		return $r;
+	}
+
+	private function blockUpdates( $pre, $r, $url ) {
+		switch ( $url ) {
+			case 'https://api.wordpress.org/plugins/update-check/1.1/':
+				return 'block_request';
+			case 'https://api.wordpress.org/themes/update-check/1.1/':
+				return 'block_request';
+			default:
+				return $pre;
+		}
+	}
+
 }

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -53,7 +53,7 @@ class Health_Check_Updates_Test extends WP_UnitTestCase {
 
 		// Check update hooks have been removed.
 		remove_filter( 'load-themes.php', 'wp_update_themes' );
-		$hooks = $this->test_updates->check_plugin_update_hooks();
+		$hooks = $this->test_updates->check_theme_update_hooks();
 		add_filter( 'load-themes.php', 'wp_update_themes' );
 		$this->assertFalse( $hooks );
 	}

--- a/tests/phpunit/test-updates.php
+++ b/tests/phpunit/test-updates.php
@@ -1,0 +1,54 @@
+<?php
+
+class Health_Check_Updates_Test extends WP_UnitTestCase {
+
+	private $test_updates;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->test_updates = new Health_Check_Updates();
+	}
+
+	public function testPluginHooks() {
+		// Check if any update hooks have been removed.
+		$hooks = $this->test_updates->check_plugin_update_hooks();
+
+		$this->assertTrue( $hooks );
+	}
+
+	public function testPluginUpdateRequest() {
+		// Check if update requests are being blocked.
+		$blocked = $this->test_updates->check_plugin_update_pre_request();
+
+		$this->assertFalse( $blocked );
+	}
+
+	public function testPluginUpdateRequestArgs() {
+		// Check if plugins have been removed from the update requests.
+		$diff = (array) $this->check_plugin_update_request_args();
+
+		$this->assertCount( 0, $diff );
+	}
+
+	public function testThemeHooks() {
+		// Check if any update hooks have been removed.
+		$hooks = $this->test_updates->check_theme_update_hooks();
+
+		$this->assertTrue( $hooks );
+	}
+
+	public function testThemeUpdateRequest() {
+		// Check if update requests are being blocked.
+		$blocked = $this->test_updates->check_theme_update_pre_request();
+
+		$this->assertFalse( $blocked );
+	}
+
+	public function testThemeUpdateRequestArgs() {
+		// Check if themes have been removed from the update requests.
+		$diff = (array) $this->check_theme_update_request_args();
+
+		$this->assertCount( 0, $diff );
+	}
+}


### PR DESCRIPTION
This PR replaces a previous one, as significant changes have occurred since then, it resolves #23.

I am not 100% sold on my naming/wording (files, translated strings, etc), but the general gist is good.

It comes with tests to ensure 'default' conditions work, however, I still need to add tests which check that it is accurately identifying foul play (removing update actions, plugins from update requests, etc).