### PR TITLE
PHP Extension tests

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -477,31 +477,31 @@ class Health_Check_Site_Status {
 		 * }
 		 */
 		$modules = array(
-			'bcmath' => array(
+			'bcmath'    => array(
 				'function' => 'bcadd',
 				'required' => false,
 			),
-			'curl' => array(
+			'curl'      => array(
 				'function' => 'curl_version',
 				'required' => false,
 			),
-			'exif' => array(
+			'exif'      => array(
 				'function' => 'exif_read_data',
 				'required' => false,
 			),
-			'filter' => array(
+			'filter'    => array(
 				'function' => 'filter_list',
 				'required' => false,
 			),
-			'fileinfo' => array(
+			'fileinfo'  => array(
 				'function' => 'finfo_file',
 				'required' => false,
 			),
-			'mod_xml' => array(
+			'mod_xml'   => array(
 				'extension' => 'libxml',
 				'required'  => false,
 			),
-			'mysqli' => array(
+			'mysqli'    => array(
 				'function' => 'mysqli_connect',
 				'required' => false,
 			),
@@ -509,24 +509,24 @@ class Health_Check_Site_Status {
 				'function' => 'sodium_compare',
 				'required' => false,
 			),
-			'openssl' => array(
+			'openssl'   => array(
 				'function' => 'openssl_encrypt',
 				'required' => false,
 			),
-			'pcre' => array(
+			'pcre'      => array(
 				'function' => 'preg_match',
 				'required' => false,
 			),
-			'imagick' => array(
+			'imagick'   => array(
 				'extension' => 'imagick',
 				'required'  => false,
 			),
-			'gd' => array(
+			'gd'        => array(
 				'extension'    => 'gd',
 				'required'     => false,
 				'fallback_for' => 'imagick',
 			),
-			'mcrypt' => array(
+			'mcrypt'    => array(
 				'extension'    => 'mcrypt',
 				'required'     => false,
 				'fallback_for' => 'libsodium',
@@ -536,7 +536,7 @@ class Health_Check_Site_Status {
 				'required'     => false,
 				'fallback_for' => 'xml',
 			),
-			'zlib' => array(
+			'zlib'      => array(
 				'extension'    => 'zlib',
 				'required'     => false,
 				'fallback_for' => 'zip'
@@ -567,6 +567,7 @@ class Health_Check_Site_Status {
 					'<span class="%s"></span> %s',
 					( $module['required'] ? 'error' : 'warning' ),
 					sprintf(
+						// translators: %1$2: If a module is required or recommended. %2$s: The module name.
 						__( 'The %1$s module, %2$s, is not installer, or has been disabled.', 'health-check' ),
 						( $module['required'] ? __( 'required', 'health-check' ) : __( 'optional', 'health-check' ) ),
 						$library

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -439,21 +439,157 @@ class Health_Check_Site_Status {
 		);
 	}
 
-	public function test_json_extension() {
-		$json_check = Health_Check::json_check();
+	public function child_test_php_extension_availability( $extension = null, $function = null ) {
+		// If no extension or function is passed, claim to fail testing, as we have nothing to test against.
+		if ( null === $extension && null === $function ) {
+			return false;
+		}
 
-		$status = 'good';
-		$notice = array();
+		$available = true;
 
-		if ( ! $json_check ) {
-			printf(
-				'<span class="error"> %s',
-				esc_html__( 'The PHP install on your server has the JSON extension disabled and is therefore not compatible with WordPress 3.2 or newer.', 'health-check' )
-			);
+		if ( null !== $extension && ! extension_loaded( $extension ) ) {
+			$available = false;
+		}
+
+		if ( null !== $function && ! function_exists( $function ) ) {
+			$available = false;
+		}
+
+		return $available;
+	}
+
+	public function test_php_extensions() {
+		/*
+		 * An array representing all the modules we wish to test for.
+		 *
+		 * array $modules {
+		 *     An associated array of modules to test for.
+		 *
+		 *     array $module {
+		 *         An associated array of module properties used during testing.
+		 *         One of either `$function` or `$extension` must be provided, or they will fail by default.
+		 *
+		 *         string $function     Optional. A function name to test for the existence of.
+		 *         string $extension    Optional. An extension to check if is loaded in PHP.
+		 *         bool   $required     Is this a required feature or not.
+		 *         string $fallback_for Optional. The module this module replaces as a fallback.
+		 *     }
+		 * }
+		 */
+		$modules = array(
+			'bcmath' => array(
+				'function' => 'bcadd',
+				'required' => false,
+			),
+			'curl' => array(
+				'function' => 'curl_version',
+				'required' => false,
+			),
+			'exif' => array(
+				'function' => 'exif_read_data',
+				'required' => false,
+			),
+			'filter' => array(
+				'function' => 'filter_list',
+				'required' => false,
+			),
+			'fileinfo' => array(
+				'function' => 'finfo_file',
+				'required' => false,
+			),
+			'mod_xml' => array(
+				'extension' => 'libxml',
+				'required'  => false,
+			),
+			'mysqli' => array(
+				'function' => 'mysqli_connect',
+				'required' => false,
+			),
+			'libsodium' => array(
+				'function' => 'sodium_compare',
+				'required' => false,
+			),
+			'openssl' => array(
+				'function' => 'openssl_encrypt',
+				'required' => false,
+			),
+			'pcre' => array(
+				'function' => 'preg_match',
+				'required' => false,
+			),
+			'imagick' => array(
+				'extension' => 'imagick',
+				'required'  => false,
+			),
+			'gd' => array(
+				'extension'    => 'gd',
+				'required'     => false,
+				'fallback_for' => 'imagick',
+			),
+			'mcrypt' => array(
+				'extension'    => 'mcrypt',
+				'required'     => false,
+				'fallback_for' => 'libsodium',
+			),
+			'xmlreader' => array(
+				'extension'    => 'xmlreader',
+				'required'     => false,
+				'fallback_for' => 'xml',
+			),
+			'zlib' => array(
+				'extension'    => 'zlib',
+				'required'     => false,
+				'fallback_for' => 'zip'
+			),
+		);
+
+		$failures = array();
+
+		foreach ( $modules as $library => $module ) {
+			$extension = ( isset( $module['extension'] ) ? $module['extension'] : null );
+			$function  = ( isset( $module['function'] ) ? $module['function'] : null );
+
+			// If this module is a fallback for another function, check if that other function passed.
+			if ( isset( $module['fallback_for'] ) ) {
+				/*
+				 * If that other function has a failure, mark this module as required for normal operations.
+				 * If that other function hasn't failed, skip this test as it's only a fallback.
+				 */
+				if ( isset( $failures[ $module['fallback_for'] ] ) ) {
+					$module['required'] = true;
+				} else {
+					continue;
+				}
+			}
+
+			if ( ! $this->child_test_php_extension_availability( $extension, $function ) ) {
+				$failures[ $library ] = sprintf(
+					'<span class="%s"></span> %s',
+					( $module['required'] ? 'error' : 'warning' ),
+					sprintf(
+						__( 'The %1$s module, %2$s, is not installer, or has been disabled.', 'health-check' ),
+						( $module['required'] ? __( 'required', 'health-check' ) : __( 'optional', 'health-check' ) ),
+						$library
+					)
+				);
+			}
+		}
+
+		if ( ! empty( $failures ) ) {
+			echo '<ul>';
+
+			foreach ( $failures as $failure ) {
+				printf(
+					'<li>%s</li>',
+					$failure
+				);
+			}
+
+			echo '</ul>';
 		} else {
 			printf(
-				'<span class="good"> %s',
-				esc_html__( 'Your PHP install supports JSON.', 'health-check' )
+				'<span class="good"></span> %s',
+				__( 'All required and recommended modules are installed.', 'health-check' )
 			);
 		}
 	}
@@ -800,8 +936,8 @@ class Health_Check_Site_Status {
 					'test'  => 'sql_server',
 				),
 				array(
-					'label' => __( 'JSON Extension', 'health-check' ),
-					'test'  => 'json_extension',
+					'label' => __( 'PHP Extensions', 'health-check' ),
+					'test'  => 'php_extensions',
 				),
 				array(
 					'label' => __( 'MySQL utf8mb4 support', 'health-check' ),

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -539,7 +539,7 @@ class Health_Check_Site_Status {
 			'zlib'      => array(
 				'extension'    => 'zlib',
 				'required'     => false,
-				'fallback_for' => 'zip'
+				'fallback_for' => 'zip',
 			),
 		);
 

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -436,21 +436,4 @@ class Health_Check {
 
 		return true;
 	}
-
-	/**
-	 * Perform a check to see is JSON is enabled.
-	 *
-	 * @uses extension_loaded()
-	 * @uses function_Exists()
-	 * @uses son_encode()
-	 *
-	 * @return bool
-	 */
-	static function json_check() {
-		$extension_loaded = extension_loaded( 'json' );
-		$functions_exist  = function_exists( 'json_encode' ) && function_exists( 'json_decode' );
-		$functions_work   = function_exists( 'json_encode' ) && ( '' != json_encode( 'my test string' ) );
-
-		return $extension_loaded && $functions_exist && $functions_work;
-	}
 }


### PR DESCRIPTION
This PR addresses #169 by adding a new test function that checks for recommended and required extensions based on hosting best practices gathered from https://make.wordpress.org/hosting/handbook/handbook/server-environment/

Some features improve on others, because of this it has a fallback option, a feature can be a fallback for another feature. This means if the recommended feature, `libsodium` (cryptography, but only available in PHP 7.0 or newer) isn't available, the fallback feature `mcrypt` is considered a requirement. But if the recommended feature exists, the fallback one will be ignored and not tested for (because it's not needed).

This PR also removes the JSON extension check, which was originally adopted from the first iteration of this plugin many years ago. The feature is built in with PHP 5.2 and newer, and we therefore don't need to be testing for it, it's always there.