### PR TITLE
Add Twenty Nineteen as a default theme

### DIFF
--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -29,7 +29,7 @@ class Health_Check_Troubleshooting_MU {
 	);
 
 	private $default_themes = array(
-        'twentynineteen',
+		'twentynineteen',
 		'twentyseventeen',
 		'twentysixteen',
 		'twentyfifteen',

--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -29,6 +29,7 @@ class Health_Check_Troubleshooting_MU {
 	);
 
 	private $default_themes = array(
+        'twentynineteen',
 		'twentyseventeen',
 		'twentysixteen',
 		'twentyfifteen',


### PR DESCRIPTION
In preparation of WordPress 5.0, add in the new default theme, Twenty Nineteen, as mentioned in #209 