### PR TITLE
Don't test how long `dotorg_communication` takes

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -953,17 +953,20 @@ class Health_Check_Site_Status {
 					wp_remote_retrieve_body( $r )
 				)
 			);
-		} elseif ( false !== ( $json = json_decode( wp_remote_retrieve_body( $r ), true ) ) && ! isset( $json['capabilities'] ) ) {
-			printf(
-				'<span class="warning"></span> %s',
-				esc_html__( 'The REST API did not process the \'context\' query parameter correctly.', 'health-check' )
-			);
 		} else {
+			$json = json_decode( wp_remote_retrieve_body( $r ), true );
 
-			printf(
-				'<span class="good"></span> %s',
-				__( 'The REST API is available.', 'health-check' )
-			);
+			if ( false !== $json && ! isset( $json['capabilities'] ) ) {
+				printf(
+					'<span class="warning"></span> %s',
+					esc_html__( 'The REST API did not process the \'context\' query parameter correctly.', 'health-check' )
+				);
+			} else {
+				printf(
+					'<span class="good"></span> %s',
+					__( 'The REST API is available.', 'health-check' )
+				);
+			}
 		}
 	}
 

--- a/tests/phpunit/test-site-status.php
+++ b/tests/phpunit/test-site-status.php
@@ -67,6 +67,7 @@ class Health_Check_Site_Status_Test extends WP_UnitTestCase {
 		// Certain tests are known to be prolonged, but will appear short in testing
 		$skip_testing = array(
 			'loopback_requests', // fail early, as there's no loopback to hit on a unit test.
+			'dotorg_communication', // Time needed to run this test heavily depends on host loads
 		);
 
 		foreach ( $tests as $test ) {


### PR DESCRIPTION
The timing needed to complete a test connection to WordPress.org depends too heavily on host loads, as such the test is prone to random failures. To resolve this, we'll allow skipping this specific scenario in our test.