### PR TITLE
Fix for plugin_data missing a slug

### DIFF
--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -299,11 +299,14 @@ class Health_Check {
 			$plugin_data['slug'] = $plugin_file;
 		}
 
+		// If a slug isn't present, use the plugin's name
+		$plugin_name = ( isset( $plugin_data['slug'] ) ? $plugin_data['slug'] : sanitize_title( $plugin_data['Name'] ) );
+
 		$actions['troubleshoot'] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( add_query_arg( array(
-				'health-check-troubleshoot-plugin' => ( isset( $plugin_data['slug'] ) ? $plugin_data['slug'] : sanitize_title( $plugin_data['Name'] ) ),
-				'_wpnonce'                         => wp_create_nonce( 'health-check-troubleshoot-plugin-' . $plugin_data['slug'] ),
+				'health-check-troubleshoot-plugin' => $plugin_name,
+				'_wpnonce'                         => wp_create_nonce( 'health-check-troubleshoot-plugin-' . $plugin_name ),
 			), admin_url( 'plugins.php' ) ) ),
 			esc_html__( 'Troubleshoot', 'health-check' )
 		);


### PR DESCRIPTION
## Short introduction
- Fix non-default index `slug` missing in array by falling back to default index `Name`
- Issue report here: https://wordpress.org/support/topic/lastest-version-1-2-4-is-causing-errors/

## Description of what the PR accomplishes
- The filter [`plugin_action_links`](https://developer.wordpress.org/reference/hooks/plugin_action_links/) uses the function [`get_plugin_data()`](https://developer.wordpress.org/reference/functions/get_plugin_data/) to set the initial value of `$plugin_data`. The index `slug` is not one of the defaults, however, and private plugins tend not to set it. The original code falls back to the plugin's name in one spot, this code just applies this to a second spot, too.

## PR Checklist
These are things to ensure are covered by your PR.
- [ x] This PR is created against the `develop` branch
- [ x] This PR is feature ready and can be reviewed in its entirety