### PR TITLE
Add missing REST API nonce header for REST tests

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -918,6 +918,7 @@ class Health_Check_Site_Status {
 		$timeout = 10;
 		$headers = array(
 			'Cache-Control' => 'no-cache',
+			'X-WP-Nonce'    => wp_create_nonce( 'wp_rest' ),
 		);
 
 		// Include Basic auth in loopback requests.


### PR DESCRIPTION
## Short introduction
The REST API tester added a query parameter approach to catch configuration, but was incorrectly reporting an authentication failure.

## Description of what the PR accomplishes
During testing of the new editing experience in WordPress, Gutenberg, it was noticed that some server setups would block the new editor's need for REST API access. We therefore included tests for these, but during the security backport a header was missed, causing the test to always fail.

This PR just re-introduces the lost header, adn restoring test functionality.


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety