### PR TITLE
Make sure all files are not directly accessible

### DIFF
--- a/src/includes/class-health-check-auto-updates.php
+++ b/src/includes/class-health-check-auto-updates.php
@@ -5,6 +5,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Health_Check_Auto_Updates
  */

--- a/src/includes/class-health-check-debug-data.php
+++ b/src/includes/class-health-check-debug-data.php
@@ -5,6 +5,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Health_Check_Debug_Data
  */

--- a/src/includes/class-health-check-files-integrity.php
+++ b/src/includes/class-health-check-files-integrity.php
@@ -6,6 +6,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Files_Integrity
  */

--- a/src/includes/class-health-check-loopback.php
+++ b/src/includes/class-health-check-loopback.php
@@ -5,6 +5,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Health_Check_Loopback
  */

--- a/src/includes/class-health-check-mail-check.php
+++ b/src/includes/class-health-check-mail-check.php
@@ -6,6 +6,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Mail Check
  */

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -1,5 +1,10 @@
 <?php
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 class Health_Check_Site_Status {
 	private $php_min_version_check;
 	private $php_supported_version_check;

--- a/src/includes/class-health-check-troubleshoot.php
+++ b/src/includes/class-health-check-troubleshoot.php
@@ -5,6 +5,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Health_Check_Troubleshoot
  */

--- a/src/includes/class-health-check-updates.php
+++ b/src/includes/class-health-check-updates.php
@@ -5,6 +5,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Health_Check_Updates
  */

--- a/src/includes/class-health-check-wp-cli.php
+++ b/src/includes/class-health-check-wp-cli.php
@@ -7,6 +7,11 @@
 
 use WP_CLI\Utils;
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Health_Check_WP_CLI
  */

--- a/src/includes/class-health-check-wp-cron.php
+++ b/src/includes/class-health-check-wp-cron.php
@@ -5,6 +5,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class Health_Check_WP_Cron
  */

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -5,6 +5,11 @@
  * @package Health Check
  */
 
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
 /**
  * Class HealthCheck
  */

--- a/src/modals/backup-warning.php
+++ b/src/modals/backup-warning.php
@@ -1,3 +1,12 @@
+<?php
+
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
+?>
+
 <div class="health-check-modal" id="health-check-backup-warning" data-modal-action="" data-parent-field="">
 	<div class="modal-content">
 		<h2>

--- a/src/modals/diff.php
+++ b/src/modals/diff.php
@@ -1,3 +1,12 @@
+<?php
+
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
+?>
+
 <div id="health-check-diff-modal">
 	<div id="health-check-diff-modal-content">
 		<a id="health-check-diff-modal-close-ref" href="#health-check-diff-modal-close"><span class="dashicons dashicons-no"></span></a>

--- a/src/modals/js-result-warnings.php
+++ b/src/modals/js-result-warnings.php
@@ -1,3 +1,12 @@
+<?php
+
+// Make sure the file is not directly accessible.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
+?>
+
 <div class="health-check-modal" data-modal-action="" data-parent-field="">
 	<div class="modal-content">
 		<span class="modal-close">&times;</span>


### PR DESCRIPTION
Resolves #237.

## Short introduction
This commit simply adds the following at the top of each PHP file:
```
// Make sure the file is not directly accessible.
if ( ! defined( 'ABSPATH' ) ) {
	die( 'We\'re sorry, but you can not directly access this file.' );
}
```

(Some files already had this.)

## Description of what the PR accomplishes
This prevents all PHP files from being directly accessed through the web server.  All these files are designed to be used via PHP `include` or `require`, and accessing them directly could have unintended results, so it is good practice to prevent this.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety