### PR TITLE
Fix backup warning not being dismissible

### DIFF
--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -202,16 +202,13 @@ class Health_Check {
 	 * @return void
 	 */
 	public function enqueues() {
-		// Don't enqueue anything unless we're on the health check page
-		if ( ! isset( $_GET['page'] ) || 'health-check' !== $_GET['page'] ) {
-
-			/*
-			 * Special consideration, if warnings are not dismissed we need to display
-			 * our modal, and thus require our styles, in other locations, before bailing.
-			 */
-			if ( ! Health_Check_Troubleshoot::has_seen_warning() ) {
-				wp_enqueue_style( 'health-check', HEALTH_CHECK_PLUGIN_URL . '/assets/css/health-check.css', array(), HEALTH_CHECK_PLUGIN_VERSION );
-			}
+		/*
+		 * Don't enqueue anything unless we're on the health check page
+		 *
+		 * Special consideration, if warnings are not dismissed we need to display
+		 * our modal, and thus require our styles, in other locations, before bailing.
+		 */
+		if ( ( ! isset( $_GET['page'] ) || 'health-check' !== $_GET['page'] ) && Health_Check_Troubleshoot::has_seen_warning() ) {
 			return;
 		}
 


### PR DESCRIPTION
Quickly ensures JS and CSS files are enqueued when the conditional to show a backup warning is triggered.

This ensures the dismiss option is stored, which was broken by the introduction of nonces in the previous release, which wouldn't be available on all apges.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety