### PR TITLE
Added prefix wp- to cookie name for added hosting compatibility

### DIFF
--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -23,7 +23,7 @@ class Health_Check_Troubleshooting_MU {
 	private $self_fetching_theme = false;
 
 	private $available_query_args = array(
-		'health-check-disable-plugins',
+		'wp-health-check-disable-plugins',
 		'health-check-disable-plugins-hash',
 		'health-check-disable-troubleshooting',
 		'health-check-change-active-theme',
@@ -277,8 +277,8 @@ class Health_Check_Troubleshooting_MU {
 	 */
 	public function is_troubleshooting() {
 		// Check if a session cookie to disable plugins has been set.
-		if ( isset( $_COOKIE['health-check-disable-plugins'] ) ) {
-			$_GET['health-check-disable-plugin-hash'] = $_COOKIE['health-check-disable-plugins'] . md5( $_SERVER['REMOTE_ADDR'] );
+		if ( isset( $_COOKIE['wp-health-check-disable-plugins'] ) ) {
+			$_GET['health-check-disable-plugin-hash'] = $_COOKIE['wp-health-check-disable-plugins'] . md5( $_SERVER['REMOTE_ADDR'] );
 		}
 
 		// If the disable hash isn't set, no need to interact with things.
@@ -462,14 +462,14 @@ class Health_Check_Troubleshooting_MU {
 			return;
 		}
 
-		if ( isset( $_COOKIE['health-check-disable-plugins'] ) ) {
+		if ( isset( $_COOKIE['wp-health-check-disable-plugins'] ) ) {
 			$this->disable_troubleshooting_mode();
 		}
 	}
 
 	function disable_troubleshooting_mode() {
-		unset( $_COOKIE['health-check-disable-plugins'] );
-		setcookie( 'health-check-disable-plugins', null, 0, COOKIEPATH, COOKIE_DOMAIN );
+		unset( $_COOKIE['wp-health-check-disable-plugins'] );
+		setcookie( 'wp-health-check-disable-plugins', null, 0, COOKIEPATH, COOKIE_DOMAIN );
 		delete_option( 'health-check-allowed-plugins' );
 		delete_option( 'health-check-default-theme' );
 		delete_option( 'health-check-current-theme' );

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -150,8 +150,8 @@ class Health_Check_Site_Status {
 
 	/**
 	 * Check if the user is currently in Troubleshooting Mode or not.
-	 *
-	 * @return bool
+	 *'wp-health-check-disable-plugins'
+	 * @return bool'wp-health-check-disable-plugins'
 	 */
 	public function is_troubleshooting() {
 		// Check if a session cookie to disable plugins has been set.

--- a/src/includes/class-health-check-troubleshoot.php
+++ b/src/includes/class-health-check-troubleshoot.php
@@ -39,7 +39,7 @@ class Health_Check_Troubleshoot {
 
 		update_option( 'health-check-disable-plugin-hash', $loopback_hash . md5( $_SERVER['REMOTE_ADDR'] ) );
 
-		setcookie( 'health-check-disable-plugins', $loopback_hash, 0, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( 'wp-health-check-disable-plugins', $loopback_hash, 0, COOKIEPATH, COOKIE_DOMAIN );
 	}
 
 	/**

--- a/tests/phpunit/test-mu-plugin.php
+++ b/tests/phpunit/test-mu-plugin.php
@@ -22,7 +22,7 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 
 	public function testTroubleshootingModeDisabledNoCookie() {
 		// Make sure we don't have the troubleshooting cookie.
-		unset( $_COOKIE['health-check-disable-plugins'] );
+		unset( $_COOKIE['wp-health-check-disable-plugins'] );
 
 		// Troubleshooting mode should be disabled by default, with no cookie declared.
 		$this->assertFalse( $this->class_instance->is_troubleshooting() );
@@ -30,7 +30,7 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 
 	public function testTroubleshootingModeDisabledWrongCookie() {
 		// Set a troubleshooting cookie with invalid data.
-		$_COOKIE['health-check-disable-plugins'] = 'abc124';
+		$_COOKIE['wp-health-check-disable-plugins'] = 'abc124';
 
 		// This test should fail, as the hash values do not match.
 		$this->assertFalse( $this->class_instance->is_troubleshooting() );
@@ -38,7 +38,7 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 
 	public function testTroubleshootingModeEnabledRightCookie() {
 		// Set a troubleshooting cookie with valid data.
-		$_COOKIE['health-check-disable-plugins'] = 'abc123';
+		$_COOKIE['wp-health-check-disable-plugins'] = 'abc123';
 
 		// This test should pass, as the hash values does now match.
 		$this->assertTrue( $this->class_instance->is_troubleshooting() );
@@ -46,7 +46,7 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 
 	public function testHasPluginsBeforeTroubleshooting() {
 		// Make sure we are not currently troubleshooting.
-		$_COOKIE['health-check-disable-plugins'] = '';
+		$_COOKIE['wp-health-check-disable-plugins'] = '';
 
 		// Fetch a list of all active plugins.
 		$all_plugins = get_option( 'active_plugins' );
@@ -59,7 +59,7 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 
 	public function testNoPluginsWhenTroubleshooting() {
 		// Enable troubleshooting
-		$_COOKIE['health-check-disable-plugins'] = 'abc123';
+		$_COOKIE['wp-health-check-disable-plugins'] = 'abc123';
 
 		// Fetch a list of all active plugins while troubleshooting.
 		$all_plugins = get_option( 'active_plugins' );
@@ -70,7 +70,7 @@ class Health_Check_MU_Plugin_Test extends WP_UnitTestCase {
 
 	public function testEnableSinglePlugin() {
 		// Make sure troubleshooting is enabled.
-		$_COOKIE['health-check-disable-plugins'] = 'abc123';
+		$_COOKIE['wp-health-check-disable-plugins'] = 'abc123';
 
 		// Add Akismet to the approved plugins list.
 		update_option( 'health-check-allowed-plugins', array( 'akismet' ) );


### PR DESCRIPTION
## Short introduction
As per issue that we discussed with @Clorith in here: https://wordpress.org/support/topic/troubleshooting-mode-in-pantheon-hosting-do-not-work/

It seems the cookie is being stripped by the Pantheon’s Varnish cache layer not letting it pass as per naming specifications defined in the platform’s Varnish configuration: https://pantheon.io/docs/cookies/#cache-busting-cookies, any cookie that do not have a wp- prefix is being stripped. I tried it in my test environment and I was able to make the plugin work by searching all strings that matches 'health-check-disable-plugins' to 'wp-health-check-disable-plugins'

## Description of what the PR accomplishes
Renamed cookie name from 'health-check-disable-plugins' to 'wp-health-check-disable-plugins'

## PR Checklist
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety