### PR TITLE
Improve "Show passed tests" button accessibility

### DIFF
--- a/assets/javascript/site-status/site-status-tests.js
+++ b/assets/javascript/site-status/site-status-tests.js
@@ -2,10 +2,11 @@
 jQuery( document ).ready(function( $ ) {
 	var data;
 
-	$( 'body.dashboard_page_health-check' ).on( 'click', '.site-health-view-passed', function() {
-		$( this ).hide();
+	$( '.site-health-view-passed' ).on( 'click', function() {
+		var goodIssuesWrapper = $( '#health-check-issues-good' );
 
-		$( '#health-check-issues-good' ).show();
+		goodIssuesWrapper.toggleClass( 'hidden' );
+		$( this ).attr( 'aria-expanded', ! goodIssuesWrapper.hasClass( 'hidden' ) );
 	});
 
 	function HCAppendIssue( issue ) {

--- a/assets/sass/modules/_site-status.scss
+++ b/assets/sass/modules/_site-status.scss
@@ -15,11 +15,6 @@ h3 {
 	text-align: center;
 }
 
-#health-check-issues-good {
-
-	display: none;
-}
-
 #progressbar {
 
 	display: inline-block;

--- a/src/pages/site-status.php
+++ b/src/pages/site-status.php
@@ -34,7 +34,7 @@ global $health_check_site_status;
 </div>
 
 <div class="view-more">
-	<button type="button" class="button button-link site-health-view-passed">
+	<button type="button" class="button button-link site-health-view-passed" aria-expanded="false">
 		<?php esc_html_e( 'Show passed tests', 'health-check' ); ?>
 	</button>
 </div>


### PR DESCRIPTION
## Short introduction
Addresses a first part of #264 

## Description of what the PR accomplishes
Improves the "Show passed tests" toggle button accessibility by:
- keeping it visible to avoid a focus loss
- using `aria-expanded`

## Screenshots
<img width="928" alt="screenshot 2019-02-23 at 21 56 34" src="https://user-images.githubusercontent.com/1682452/53291592-ef9a8400-37b5-11e9-870f-a7c6c5c64bb2.png">


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety