### PR TITLE
Add 'Error' screen reader text to file integrity table

### DIFF
--- a/src/includes/class-health-check-files-integrity.php
+++ b/src/includes/class-health-check-files-integrity.php
@@ -127,6 +127,7 @@ class Health_Check_Files_Integrity {
 			$output .= '</td></tr></tfoot><tbody>';
 			foreach ( $files as $tampered ) {
 				$output .= '<tr>';
+				$output .= '<span class="screen-reader-text">' . esc_html__( 'Error', 'health-check' ) . '</span>';
 				$output .= '<td><span class="error"></span></td>';
 				$output .= '<td>' . $filepath . $tampered[0] . '</td>';
 				$output .= '<td>' . $tampered[1] . '</td>';


### PR DESCRIPTION
## Short introduction
- Related: #267

## Description of what the PR accomplishes
Proposed HTML markup:
```
<tr>
   <td><span class="screen-reader-text">Error</span><span class="error"></span></td> 
   <td>/wp-admin/js/widgets.js</td><td>Content changed <a href="#health-check-diff" data-file="wp-admin/js/widgets.js">(View Diff)</a></td>
</tr>
```

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety