### PR TITLE
Improve show all themes and plugins buttons accessibility.

### DIFF
--- a/assets/javascript/health-check-troubleshooting-mode.js
+++ b/assets/javascript/health-check-troubleshooting-mode.js
@@ -1,0 +1,24 @@
+/* global HealthCheckTroubleshootingModeL10n */
+jQuery( document ).ready(function( $ ) {
+	$( '.health-check-toggle-visibility' ).click(function() {
+		var which = $( this ).data( 'element' ),
+			$icon = $( this ).find( '.icon' ),
+			$elements = $( '.toggle-visibility', $( '#' + which ).closest( '.welcome-panel-column' ) ),
+			showAllText = HealthCheckTroubleshootingModeL10n.showAllPlugins,
+			showFewerText = HealthCheckTroubleshootingModeL10n.showFewerPlugins,
+			isExpanded = false;
+
+		if ( 'health-check-themes' === which ) {
+			showAllText = HealthCheckTroubleshootingModeL10n.showAllThemes;
+			showFewerText = HealthCheckTroubleshootingModeL10n.showFewerThemes;
+		}
+
+		$elements.toggleClass( 'hidden' );
+		$icon.toggleClass( 'icon-up' );
+		isExpanded = $icon.hasClass( 'icon-up' );
+
+		$( this )
+			.attr( 'aria-expanded', isExpanded )
+			.find( '.health-check-toggle-text' ).text( isExpanded ? showFewerText : showAllText );
+	});
+});

--- a/assets/sass/health-check-troubleshooting-mode.scss
+++ b/assets/sass/health-check-troubleshooting-mode.scss
@@ -45,16 +45,6 @@
 		}
 	}
 
-	.toggle-visibility {
-
-		display: none;
-
-		&.visible {
-
-			display: block;
-		}
-	}
-
 	.welcome-panel-column-container {
 
 		position: initial;

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -59,10 +59,20 @@ module.exports = function( grunt ) {
 		},
 		copy: {
 			files: {
-				cwd: 'src/',
-				src: '**/*',
-				dest: 'build/',
-				expand: true
+				files: [
+					{
+						cwd: 'src/',
+						src: '**/*',
+						dest: 'build/',
+						expand: true
+					},
+					{
+						cwd: 'assets/',
+						src: 'javascript/health-check-troubleshooting-mode.js',
+						dest: 'build/assets/',
+						expand: true
+					}
+				]
 			},
 			documents: {
 				cwd: 'docs/plugin/',
@@ -130,7 +140,10 @@ module.exports = function( grunt ) {
 		},
 		concat: {
 			healthcheck: {
-				src: [ 'assets/javascript/**/*.js' ],
+				src: [
+					'assets/javascript/**/*.js',
+					'!assets/javascript/health-check-troubleshooting-mode.js'
+				],
 				dest: 'build/assets/javascript/health-check.js'
 			}
 		},

--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -75,7 +75,7 @@ class Health_Check_Troubleshooting_MU {
 		add_action( 'wp_logout', array( $this, 'health_check_troubleshooter_mode_logout' ) );
 		add_action( 'init', array( $this, 'health_check_troubleshoot_get_captures' ) );
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		/*
 		 * Plugin activations can be forced by other tools in things like themes, so let's
@@ -102,16 +102,25 @@ class Health_Check_Troubleshooting_MU {
 	}
 
 	/**
-	 * Enqueue styles used by the MU plugin if applicable.
+	 * Enqueue styles and scripts used by the MU plugin if applicable.
 	 *
 	 * @return void
 	 */
-	public function enqueue_styles() {
+	public function enqueue_assets() {
 		if ( ! $this->is_troubleshooting() || ! is_admin() ) {
 			return;
 		}
 
+		$troubleshooting_mode_l10n = array(
+			'showAllPlugins'   => esc_html__( 'Show all plugins', 'health-check' ),
+			'showFewerPlugins' => esc_html__( 'Show fewer plugins', 'health-check' ),
+			'showAllThemes'    => esc_html__( 'Show all themes', 'health-check' ),
+			'showFewerThemes'  => esc_html__( 'Show fewer themes', 'health-check' ),
+		);
+
 		wp_enqueue_style( 'health-check-troubleshooting-mode', plugins_url( '/health-check/assets/css/health-check-troubleshooting-mode.css' ), array(), HEALTH_CHECK_TROUBLESHOOTING_MODE_PLUGIN_VERSION );
+		wp_enqueue_script( 'health-check-troubleshooting-mode', plugins_url( '/health-check/assets/javascript/health-check-troubleshooting-mode.js' ), array( 'jquery' ), HEALTH_CHECK_TROUBLESHOOTING_MODE_PLUGIN_VERSION, true );
+		wp_localize_script( 'health-check-troubleshooting-mode', 'HealthCheckTroubleshootingModeL10n', $troubleshooting_mode_l10n );
 	}
 
 	/**
@@ -773,21 +782,6 @@ class Health_Check_Troubleshooting_MU {
 		if ( 'dashboard' !== $screen->id && 'plugins' !== $screen->id ) {
 			return;
 		}
-		?>
-<script type="text/javascript">
-	jQuery( document ).ready(function( $ ) {
-		$( '.health-check-toggle-visibility' ).click(function() {
-			var $elements = $( '.toggle-visibility', $( '#' + $ ( this ).data( 'element' ) ).closest( '.welcome-panel-column' ) );
-
-			if ( $elements.is( ':visible' ) ) {
-				$elements.attr( 'aria-hidden', 'false' ).toggle();
-			} else {
-				$elements.attr( 'aria-hidden', 'true' ).toggle();
-			}
-		});
-	});
-</script>
-		<?php
 	}
 
 	public function display_dashboard_widget() {
@@ -871,6 +865,15 @@ class Health_Check_Troubleshooting_MU {
 									<?php esc_html_e( 'Available Plugins', 'health-check' ); ?>
 								</h3>
 
+								<?php if ( count( $this->active_plugins ) > 5 ) : ?>
+								<p>
+									<button type="button" class="button button-link health-check-toggle-visibility" data-element="health-check-plugins" aria-expanded="false">
+										<span class="health-check-toggle-text"><?php esc_html_e( 'Show all plugins', 'health-check' ); ?></span>
+										<span class="icon" aria-hidden="true"></span>
+									</button>
+								</p>
+								<?php endif; ?>
+
 								<ul id="health-check-plugins">
 									<?php
 									$active_plugins   = array();
@@ -922,27 +925,14 @@ class Health_Check_Troubleshooting_MU {
 										}
 
 										printf(
-											'<li class="%s" aria-hidden="%s">%s - %s</li>',
-											( ! $plugin_is_visible ? 'toggle-visibility' : '' ),
-											( ! $plugin_is_visible ? 'true' : 'false' ),
+											'<li class="%s">%s - %s</li>',
+											( ! $plugin_is_visible ? 'toggle-visibility hidden' : '' ),
 											esc_html( $plugin_data['Name'] ),
 											implode( ' | ', $actions )
 										);
 									}
 									?>
 								</ul>
-
-								<?php if ( count( $this->active_plugins ) > 5 ) : ?>
-								<p>
-									<button type="button" class="button button-link health-check-toggle-visibility toggle-visibility visible" aria-hidden="false" data-element="health-check-plugins">
-										<?php esc_html_e( 'Show all plugins', 'health-check' ); ?> <span class="icon"></span>
-									</button>
-
-									<button type="button" class="button button-link health-check-toggle-visibility toggle-visibility" aria-hidden="true" data-element="health-check-plugins">
-										<?php esc_html_e( 'Show fewer plugins', 'health-check' ); ?> <span class="icon icon-up"></span>
-									</button>
-								</p>
-								<?php endif; ?>
 							<?php endif; ?>
 						</div>
 
@@ -953,10 +943,21 @@ class Health_Check_Troubleshooting_MU {
 									<?php esc_html_e( 'Available Themes', 'health-check' ); ?>
 								</h3>
 
+								<?php
+								$themes = wp_prepare_themes_for_js();
+								?>
+
+								<?php if ( count( $themes ) > 5 ) : ?>
+								<p>
+									<button type="button" class="button button-link health-check-toggle-visibility" data-element="health-check-themes" aria-expanded="false">
+										<span class="health-check-toggle-text"><?php esc_html_e( 'Show all themes', 'health-check' ); ?></span>
+										<span class="icon" aria-hidden="true"></span>
+									</button>
+								</p>
+								<?php endif; ?>
+
 								<ul id="health-check-themes">
 									<?php
-									$themes = wp_prepare_themes_for_js();
-
 									foreach ( $themes as $count => $theme ) {
 										$active = $theme['active'];
 
@@ -992,26 +993,13 @@ class Health_Check_Troubleshooting_MU {
 										}
 
 										printf(
-											'<li class="%s" aria-hidden="%s">%s</li>',
-											( $theme_is_visible ? '' : 'toggle-visibility' ),
-											( $theme_is_visible ? 'false' : 'true' ),
+											'<li class="%s">%s</li>',
+											( ! $theme_is_visible ? 'toggle-visibility hidden' : '' ),
 											$plugin_label
 										);
 									}
 									?>
 								</ul>
-
-								<?php if ( count( $themes ) > 5 ) : ?>
-									<p>
-										<button type="button" class="button button-link health-check-toggle-visibility toggle-visibility visible" aria-hidden="false" data-element="health-check-themes">
-											<?php esc_html_e( 'Show all themes', 'health-check' ); ?> <span class="icon"></span>
-										</button>
-
-										<button type="button" class="button button-link health-check-toggle-visibility toggle-visibility" aria-hidden="true"  data-element="health-check-themes">
-											<?php esc_html_e( 'Show fewer themes', 'health-check' ); ?> <span class="icon icon-up"></span>
-										</button>
-									</p>
-								<?php endif; ?>
 							<?php endif; ?>
 						</div>
 

--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -874,7 +874,7 @@ class Health_Check_Troubleshooting_MU {
 								</p>
 								<?php endif; ?>
 
-								<ul id="health-check-plugins">
+								<ul id="health-check-plugins" role="list">
 									<?php
 									$active_plugins   = array();
 									$inactive_plugins = array();
@@ -956,7 +956,7 @@ class Health_Check_Troubleshooting_MU {
 								</p>
 								<?php endif; ?>
 
-								<ul id="health-check-themes">
+								<ul id="health-check-themes" role="list">
 									<?php
 									foreach ( $themes as $count => $theme ) {
 										$active = $theme['active'];


### PR DESCRIPTION
## Short introduction
Addresses the second part of #264


## Description of what the PR accomplishes
- Improves the "Show all/fewer" toggle buttons accessibility.

- uses only one button to avoid focus loss
- moves the button to the top of the list, as the expanded panel should be placed _after_ the toggle. See https://github.com/WordPress/health-check/issues/264#issuecomment-466781300
- dynamically updates the button `aria-expanded` and text
- moves the JS to a separate file for the MU plugin
- adds a localized script for the l10n strings
- removes unnecessary `aria-hidden` attributes

Note: the grunt tasks are updated accordingly. I guess this part is going to be changed anyways when merging in core.


## Screenshots

Before:

<img width="736" alt="before" src="https://user-images.githubusercontent.com/1682452/53300568-777d9e00-3849-11e9-8217-f54070287f46.png">

After:

<img width="700" alt="after" src="https://user-images.githubusercontent.com/1682452/53300570-7c425200-3849-11e9-9c30-8aeb025a165a.png">


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety