### PR TITLE
Fix heading hierarchy

### DIFF
--- a/assets/javascript/site-status/site-status-tests.js
+++ b/assets/javascript/site-status/site-status-tests.js
@@ -20,7 +20,7 @@ jQuery( document ).ready(function( $ ) {
 
 		issueCounter = $( '.issue-count', issueWrapper );
 
-		htmlOutput = '<dt role="heading" aria-level="2">\n' +
+		htmlOutput = '<dt role="heading" aria-level="4">\n' +
 			'                <button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-' + issue.test + '" id="health-check-accordion-heading-' + issue.test + '" type="button">\n' +
 			'                    <span class="title">\n' +
 			'                        ' + issue.label + '\n' +

--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -58,7 +58,7 @@ foreach ( $info as $section => $details ) {
 		continue;
 	}
 	?>
-	<dt role="heading" aria-level="2">
+	<dt role="heading" aria-level="3">
 		<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-<?php echo esc_attr( $section ); ?>" id="health-check-accordion-heading-<?php echo esc_attr( $section ); ?>" type="button">
 			<span class="title">
 				<?php echo esc_html( $details['label'] ); ?>

--- a/src/pages/tools.php
+++ b/src/pages/tools.php
@@ -43,7 +43,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	foreach ( $tabs as $count => $tab ) :
 		?>
 
-	<dt role="heading" aria-level="2">
+	<dt role="heading" aria-level="3">
 		<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-<?php echo esc_attr( $count ); ?>" id="health-check-accordion-heading-<?php echo esc_attr( $count ); ?>" type="button">
 			<span class="title">
 				<?php echo $tab['label']; ?>


### PR DESCRIPTION
Make sure the accordion `aria-level` declarations match the correct heading level they are at, previously they all had a H2 meaning, now they should be following the hierarchy of the rest of the page they are on.


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety