### PR TITLE
Add screen reader text to status spans

### DIFF
--- a/src/includes/class-health-check-files-integrity.php
+++ b/src/includes/class-health-check-files-integrity.php
@@ -132,7 +132,7 @@ class Health_Check_Files_Integrity {
 			$output .= '</td></tr></tfoot><tbody>';
 			foreach ( $files as $tampered ) {
 				$output .= '<tr>';
-				$output .= '<td><span class="error"></span></td>';
+				$output .= '<td><span class="error"><span class="screen-reader-text">' . esc_html__( 'Error', 'health-check' ) . '</span></span></td>';
 				$output .= '<td>' . $filepath . $tampered[0] . '</td>';
 				$output .= '<td>' . $tampered[1] . '</td>';
 				$output .= '</tr>';

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -1212,7 +1212,6 @@ class Health_Check_Site_Status {
 				$severity_string = esc_html__( 'Warning', 'health-check' );
 			}
 
-
 			$output .= sprintf(
 				'<li><span class="%s"><span class="screen-reader-text">%s</span></span> %s</li>',
 				esc_attr( $test->severity ),

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -748,8 +748,9 @@ class Health_Check_Site_Status {
 				}
 
 				$failures[ $library ] = sprintf(
-					'<span class="%s"></span> %s',
+					'<span class="%s"><span class="screen-reader-text">%s</span></span> %s',
 					( $module['required'] ? 'error' : 'warning' ),
+					( $module['required'] ? esc_html__( 'Error', 'health-check' ) : esc_html__( 'Warning', 'health-check' ) ),
 					sprintf(
 						// translators: %1$2: If a module is required or recommended. %2$s: The module name.
 						__( 'The %1$s module, %2$s, is not installed, or has been disabled.', 'health-check' ),
@@ -1001,7 +1002,8 @@ class Health_Check_Site_Status {
 			$result['description'] .= sprintf(
 				'<p>%s</p>',
 				sprintf(
-					'<span class="error"></span> %s',
+					'<span class="error"><span class="screen-reader-text">%s</span></span> %s',
+					esc_html__( 'Error', 'health-check' ),
 					sprintf(
 						// translators: %1$s: The IP address WordPress.org resolves to. %2$s: The error returned by the lookup.
 						__( 'Your site is unable to reach WordPress.org at %1$s, and returned the error: %2$s', 'health-check' ),
@@ -1192,21 +1194,29 @@ class Health_Check_Site_Status {
 		$output = '<ul>';
 
 		foreach ( $tests as $test ) {
+			$severity_string = esc_html__( 'Passed', 'health-check' );
+
 			if ( 'fail' === $test->severity ) {
 				$result['label'] = esc_html__( 'Background updates are not working as expected', 'health-check' );
 
 				$result['status'] = 'critical';
+
+				$severity_string = esc_html__( 'Error', 'health-check' );
 			}
 
 			if ( 'warning' === $test->severity && 'good' === $result['status'] ) {
 				$result['label'] = esc_html__( 'Background updates may not be working properly', 'health-check' );
 
 				$result['status'] = 'recommended';
+
+				$severity_string = esc_html__( 'Warning', 'health-check' );
 			}
 
+
 			$output .= sprintf(
-				'<li><span class="%s"></span> %s</li>',
+				'<li><span class="%s"><span class="screen-reader-text">%s</span></span> %s</li>',
 				esc_attr( $test->severity ),
+				$severity_string,
 				$test->desc
 			);
 		}
@@ -1249,21 +1259,28 @@ class Health_Check_Site_Status {
 		$output = '<ul>';
 
 		foreach ( $tests as $test ) {
+			$severity_string = esc_html__( 'Passed', 'health-check' );
+
 			if ( 'fail' === $test->severity ) {
 				$result['label'] = esc_html__( 'Plugin or theme updates are not working', 'health-check' );
 
 				$result['status'] = 'critical';
+
+				$severity_string = esc_html__( 'Error', 'health-check' );
 			}
 
 			if ( 'warning' === $test->severity && 'good' === $result['status'] ) {
 				$result['label'] = esc_html__( 'Some plugin or theme updates may not work as expected', 'health-check' );
 
 				$result['status'] = 'recommended';
+
+				$severity_string = esc_html__( 'Warning', 'health-check' );
 			}
 
 			$output .= sprintf(
-				'<li><span class="%s"></span> %s</li>',
+				'<li><span class="%s"><span class="screen-reader-text">%s</span></span> %s</li>',
 				esc_attr( $test->severity ),
+				$severity_string,
 				$test->desc
 			);
 		}

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -313,20 +313,21 @@ class Health_Check {
 			$critical_issues = absint( $issue_counts->critical );
 		}
 
+		$critical_count = sprintf(
+			'<span class="update-plugins count-%d"><span class="update-count">%s</span></span>',
+			esc_attr( $critical_issues ),
+			sprintf(
+				'%d<span class="screen-reader-text"> %s</span>',
+				esc_html( $critical_issues ),
+				esc_html_x( 'Critical issues', 'Issue counter label for the admin menu', 'health-check' )
+			)
+		);
+
 		$menu_title =
 			sprintf(
 				// translators: %s: Critical issue counter, if any.
 				_x( 'Site Health %s', 'Menu Title', 'health-check' ),
-				( ! $issue_counts || $critical_issues < 1 ? '' : sprintf(
-					'<span class="update-plugins count-%d"><span class="update-count">%s</span></span>',
-					esc_attr( $critical_issues ),
-                    sprintf(
-                        '%d<span class="screen-reader-text"> %s</span>',
-                        esc_html( $critical_issues ),
-                        esc_html_x( 'Critical issues', 'Issue counter label for the admin menu', 'health-check' )
-                        )
-					)
-				)
+				( ! $issue_counts || $critical_issues < 1 ? '' : $critical_count )
 			);
 
 		add_dashboard_page(

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -310,18 +310,27 @@ class Health_Check {
 		if ( false !== $issue_counts ) {
 			$issue_counts = json_decode( $issue_counts );
 
-			$critical_issues = esc_html( $issue_counts->critical );
+			$critical_issues = absint( $issue_counts->critical );
 		}
 
 		$menu_title =
 			sprintf(
 				// translators: %s: Critical issue counter, if any.
-				_x( 'Site Health %s', 'Menu, Section and Page Title', 'health-check' ),
-				( true ? sprintf( '<span class="awaiting-mod">%d</span>', absint( $critical_issues ) ) : '' )
+				_x( 'Site Health %s', 'Menu Title', 'health-check' ),
+				( ! $issue_counts || $critical_issues < 1 ? '' : sprintf(
+					'<span class="update-plugins count-%d"><span class="update-count">%s</span></span>',
+					esc_attr( $critical_issues ),
+                    sprintf(
+                        '%d<span class="screen-reader-text"> %s</span>',
+                        esc_html( $critical_issues ),
+                        esc_html_x( 'Critical issues', 'Issue counter label for the admin menu', 'health-check' )
+                        )
+					)
+				)
 			);
 
 		add_dashboard_page(
-			_x( 'Site Health', 'Menu, Section and Page Title', 'health-check' ),
+			_x( 'Site Health', 'Page Title', 'health-check' ),
 			$menu_title,
 			'manage_options',
 			'health-check',


### PR DESCRIPTION
Spans with status indicating symbols have been used, both in the site status checks, but also to represent an error state in the integrity checker tools.

This PR combines the work begun in #269, and expands it to also cover the site status tests to address #267 and #275.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety