### PR TITLE
Improve contrasts in the troubleshooting dashboard widget

### DIFF
--- a/assets/sass/health-check-troubleshooting-mode.scss
+++ b/assets/sass/health-check-troubleshooting-mode.scss
@@ -16,7 +16,7 @@
 
 			p {
 
-				color: #bfc3c7;
+				color: inherit;
 				font-size: 1.2rem;
 			}
 		}
@@ -67,6 +67,7 @@
 
 	.about-description {
 
+		color: inherit;
 		margin: 1em 0;
 	}
 


### PR DESCRIPTION
Forces all text in the Troubleshooting widget to use the default body color of wp-admin, improving the overall contrast for all the text here.

![image](https://user-images.githubusercontent.com/468735/53497858-6c26ae80-3aa5-11e9-970e-6154640d293c.png)

Text changes for the box will also be added, but that's not part of the contrast resolution.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety