### PR TITLE
Fix enqueue conditional

### DIFF
--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -189,13 +189,8 @@ class Health_Check {
 	 * @return void
 	 */
 	public function enqueues() {
-		/*
-		 * Don't enqueue anything unless we're on the health check page
-		 *
-		 * Special consideration, if warnings are not dismissed we need to display
-		 * our modal, and thus require our styles, in other locations, before bailing.
-		 */
-		if ( ( ! isset( $_GET['page'] ) || 'health-check' !== $_GET['page'] ) && Health_Check_Troubleshoot::has_seen_warning() ) {
+		// Don't enqueue anything unless we're on the health check page.
+		if ( ! isset( $_GET['page'] ) || 'health-check' !== $_GET['page'] ) {
 			return;
 		}
 


### PR DESCRIPTION
The removal of the backup warning in #283 left a lingering conditional that would fail outside our plugin pages.

As testing was limited to plugin pages, this wasn't caught pre-commit.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety