### PR TITLE
Add `aria-current` to the selected page.

### DIFF
--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -414,13 +414,14 @@ class Health_Check {
 				<?php
 				foreach ( $tabs as $tab => $label ) {
 					printf(
-						'<a href="%s" class="tab %s">%s</a>',
+						'<a href="%s" class="tab %s"%s>%s</a>',
 						sprintf(
 							'%s&tab=%s',
 							menu_page_url( 'health-check', false ),
 							$tab
 						),
 						( $current_tab === $tab ? 'active' : '' ),
+						( $current_tab === $tab ? ' aria-current="true"' : '' ),
 						$label
 					);
 				}


### PR DESCRIPTION
As per #286, we should denote the current tab with an `aria-current`, this PR introduces that attribute.

It uses `aria-current="true"`, as the current page is already declared by the admin menu, so re-declaring this would be wrong.


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety