### PR TITLE
Improve the copy to clipboard button behavior

### DIFF
--- a/assets/javascript/debug-information/copy-field.js
+++ b/assets/javascript/debug-information/copy-field.js
@@ -1,7 +1,7 @@
 /* global HealthCheck, wp */
 jQuery( document ).ready(function( $ ) {
 	$( '.health-check-copy-field' ).click(function( e ) {
-		var $textarea = $( 'system-information-' + $( this ).data( 'copy-field' ) + '-copy-field' ),
+		var $textarea = $( '#system-information-' + $( this ).data( 'copy-field' ) + '-copy-field' ),
 			$wrapper = $( this ).closest( 'div' );
 
 		e.preventDefault();
@@ -9,9 +9,26 @@ jQuery( document ).ready(function( $ ) {
 		$textarea.select();
 
 		if ( document.execCommand( 'copy' ) ) {
-			$( 'copy-field-success', $wrapper ).addClass( 'visible' );
+			$( '.copy-field-success', $wrapper ).addClass( 'visible' );
+			$( this ).focus();
 
 			wp.a11y.speak( HealthCheck.string.site_info_copied, 'polite' );
+		}
+	});
+
+	$( '.health-check-toggle-copy-section' ).click(function( e ) {
+		var $copySection = $( '.system-information-copy-wrapper' );
+
+		e.preventDefault();
+
+		if ( $copySection.hasClass( 'hidden' ) ) {
+			$copySection.removeClass( 'hidden' );
+
+			$( this ).text( HealthCheck.string.site_info_hide_copy );
+		} else {
+			$copySection.addClass( 'hidden' );
+
+			$( this ).text( HealthCheck.string.site_info_show_copy );
 		}
 	});
 });

--- a/assets/sass/modules/_info.scss
+++ b/assets/sass/modules/_info.scss
@@ -1,17 +1,31 @@
 .system-information-copy-wrapper {
 
-	width: 0;
-	height: 0;
-	overflow: hidden;
-	line-height: 0;
-	padding: 0;
-	resize: none;
-	border: none;
+	display: block;
+	margin: 1rem 0;
+
+	&.hidden {
+
+		display: none;
+	}
+
+	textarea {
+
+		width: 100%;
+	}
+
+	.copy-button-wrapper {
+
+		margin: 0.5rem 0 1rem;
+	}
 }
 
 .copy-field-success {
 
 	display: none;
+	color: #40860a;
+	font-size: $font_size__text;
+	line-height: 1.8;
+	margin-left: 0.5rem;
 
 	&.visible {
 

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -200,6 +200,8 @@ class Health_Check {
 				'copied'               => esc_html__( 'Copied', 'health-check' ),
 				'running_tests'        => esc_html__( 'Currently being tested...', 'health-check' ),
 				'site_health_complete' => esc_html__( 'All site health tests have finished running.', 'health-check' ),
+				'site_info_show_copy'  => esc_html__( 'Show options for copying this information', 'health-check' ),
+				'site_info_hide_copy'  => esc_html__( 'Hide options for copying this information', 'health-check' ),
 				'site_info_copied'     => esc_html__( 'Site information has been added to your clipboard.', 'health-check' ),
 			),
 			'nonce'       => array(

--- a/src/pages/debug-data.php
+++ b/src/pages/debug-data.php
@@ -19,36 +19,44 @@ $info = Health_Check_Debug_Data::debug_data();
 	<?php esc_html_e( 'Site Info', 'health-check' ); ?>
 </h2>
 
-<textarea id="system-information-default-copy-field" class="system-information-copy-wrapper" rows="10"><?php Health_Check_Debug_Data::textarea_format( $info ); ?></textarea>
-
-<?php
-if ( 'en_US' !== get_locale() && version_compare( get_bloginfo( 'version' ), '4.7', '>=' ) ) :
-
-	$english_info = Health_Check_Debug_Data::debug_data( 'en_US' );
-
-	// Workaround for locales not being properly loaded back, see issue #30 on GitHub.
-	if ( ! is_textdomain_loaded( 'health-check' ) && _get_path_to_translation( 'health-check' ) ) {
-		load_textdomain( 'health-check', _get_path_to_translation( 'health-check' ) );
-	}
-	?>
-	<textarea id="system-information-english-copy-field" class="system-information-copy-wrapper" rows="10"><?php Health_Check_Debug_Data::textarea_format( $english_info ); ?></textarea>
-
-<?php endif; ?>
-
 <p>
 	<?php esc_html_e( 'You can export the information on this page so it can be easily copied and pasted in support requests such as on the WordPress.org forums, or shared with your website / theme / plugin developers.', 'health-check' ); ?>
 </p>
 
-<div class="copy-button-wrapper">
-	<button type="button" class="button button-primary health-check-copy-field" data-copy-field="default"><?php esc_html_e( 'Copy to clipboard', 'health-check' ); ?></button>
-	<span class="copy-field-success">Copied!</span>
-</div>
-<?php if ( 'en_US' !== get_locale() && version_compare( get_bloginfo( 'version' ), '4.7', '>=' ) ) : ?>
+<p>
+	<button type="button" class="button button-link health-check-toggle-copy-section">
+		<?php esc_html_e( 'Show options for copying this information', 'health-check' ); ?>
+	</button>
+</p>
+
+<div class="system-information-copy-wrapper hidden">
+	<textarea id="system-information-default-copy-field" rows="10"><?php Health_Check_Debug_Data::textarea_format( $info ); ?></textarea>
+
+	<?php
+	if ( 'en_US' !== get_locale() && version_compare( get_bloginfo( 'version' ), '4.7', '>=' ) ) :
+
+		$english_info = Health_Check_Debug_Data::debug_data( 'en_US' );
+
+		// Workaround for locales not being properly loaded back, see issue #30 on GitHub.
+		if ( ! is_textdomain_loaded( 'health-check' ) && _get_path_to_translation( 'health-check' ) ) {
+			load_textdomain( 'health-check', _get_path_to_translation( 'health-check' ) );
+		}
+		?>
+		<textarea id="system-information-english-copy-field" class="system-information-copy-wrapper" rows="10"><?php Health_Check_Debug_Data::textarea_format( $english_info ); ?></textarea>
+
+	<?php endif; ?>
+
 	<div class="copy-button-wrapper">
-		<button type="button" class="button health-check-copy-field" data-copy-field="english"><?php esc_html_e( 'Copy to clipboard (English)', 'health-check' ); ?></button>
-		<span class="copy-field-success">Copied!</span>
+		<button type="button" class="button button-primary health-check-copy-field" data-copy-field="default"><?php esc_html_e( 'Copy to clipboard', 'health-check' ); ?></button>
+		<span class="copy-field-success" aria-hidden="true">Copied!</span>
 	</div>
-<?php endif; ?>
+	<?php if ( 'en_US' !== get_locale() && version_compare( get_bloginfo( 'version' ), '4.7', '>=' ) ) : ?>
+		<div class="copy-button-wrapper">
+			<button type="button" class="button health-check-copy-field" data-copy-field="english"><?php esc_html_e( 'Copy to clipboard (English)', 'health-check' ); ?></button>
+			<span class="copy-field-success" aria-hidden="true">Copied!</span>
+		</div>
+	<?php endif; ?>
+</div>
 
 <dl id="health-check-debug" role="presentation" class="health-check-accordion">
 


### PR DESCRIPTION
This PR changes how the copy to clipboard feature works, making it reveal a text area for copying as in previous iterations, but with a copy button that retains focus on the button for accessibility.

It also uses `wp.a11y.speak` to announce that text was copied, and hides the on-screen text stating the same (to avoid causing confusion to the users).

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety