### PR TITLE
Harden the file consistency checker

### DIFF
--- a/src/health-check.php
+++ b/src/health-check.php
@@ -9,7 +9,7 @@
  * Plugin URI: https://wordpress.org/plugins/health-check/
  * Description: Checks the health of your WordPress install.
  * Author: The WordPress.org community
- * Version: 1.2.4
+ * Version: 1.2.6
  * Author URI: https://wordpress.org/plugins/health-check/
  * Text Domain: health-check
  */
@@ -35,7 +35,7 @@ define( 'HEALTH_CHECK_MYSQL_MIN_VERSION', '5.0' );
 define( 'HEALTH_CHECK_MYSQL_REC_VERSION', '5.6' );
 
 // Set the plugin version.
-define( 'HEALTH_CHECK_PLUGIN_VERSION', '1.2.4' );
+define( 'HEALTH_CHECK_PLUGIN_VERSION', '1.2.6' );
 
 // Set the absolute path for the plugin.
 define( 'HEALTH_CHECK_PLUGIN_DIRECTORY', plugin_dir_path( __FILE__ ) );

--- a/src/includes/class-health-check-files-integrity.php
+++ b/src/includes/class-health-check-files-integrity.php
@@ -51,6 +51,8 @@ class Health_Check_Files_Integrity {
 		// Encode the API response body.
 		$checksumapibody = json_decode( wp_remote_retrieve_body( $checksumapi ), true );
 
+		set_transient( 'health-check-checksums', $checksumapibody, 2 * HOUR_IN_SECONDS );
+
 		// Remove the wp-content/ files from checking
 		foreach ( $checksumapibody['checksums'] as $file => $checksum ) {
 			if ( false !== strpos( $file, 'wp-content/' ) ) {
@@ -172,7 +174,18 @@ class Health_Check_Files_Integrity {
 		$wpversion = get_bloginfo( 'version' );
 
 		if ( 0 !== validate_file( $filepath . $file ) ) {
-			wp_send_json_error();
+			wp_send_json_error( array( 'message' => esc_html__( 'You do not have access to this file.' , 'health-check' ) ) );
+		}
+
+		$allowed_files = get_transient( 'health-check-checksums' );
+		if ( false === $allowed_files ) {
+			Health_Check_Files_Integrity::call_checksum_api();
+
+			$allowed_files = get_transient( 'health-check-checksums' );
+		}
+
+		if ( ! isset( $allowed_files['checksums'][ $file ] ) ) {
+			wp_send_json_error( array( 'message' => esc_html__( 'You do not have access to this file.' , 'health-check' ) ) );
 		}
 
 		$local_file_body  = file_get_contents( $filepath . $file, FILE_USE_INCLUDE_PATH );

--- a/src/includes/class-health-check-files-integrity.php
+++ b/src/includes/class-health-check-files-integrity.php
@@ -174,7 +174,7 @@ class Health_Check_Files_Integrity {
 		$wpversion = get_bloginfo( 'version' );
 
 		if ( 0 !== validate_file( $filepath . $file ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'You do not have access to this file.' , 'health-check' ) ) );
+			wp_send_json_error( array( 'message' => esc_html__( 'You do not have access to this file.', 'health-check' ) ) );
 		}
 
 		$allowed_files = get_transient( 'health-check-checksums' );
@@ -185,7 +185,7 @@ class Health_Check_Files_Integrity {
 		}
 
 		if ( ! isset( $allowed_files['checksums'][ $file ] ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'You do not have access to this file.' , 'health-check' ) ) );
+			wp_send_json_error( array( 'message' => esc_html__( 'You do not have access to this file.', 'health-check' ) ) );
 		}
 
 		$local_file_body  = file_get_contents( $filepath . $file, FILE_USE_INCLUDE_PATH );


### PR DESCRIPTION
Harden the file consistency checker by limiting what files can be looked up to only include base core files.