### PR TITLE
Site status test runners

### DIFF
--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -1022,6 +1022,53 @@ class Health_Check_Site_Status {
 		wp_send_json_success( $this->get_test_dotorg_communication() );
 	}
 
+	public function get_test_is_in_debug_mode() {
+		$result = array(
+			'label'       => esc_html__( 'Your site is not set to output debug information', 'health-check' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => 'Security',
+				'color' => 'red',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				esc_html__( 'Debug mode is often enabled to gather more details about an error or site failure, but may contain sensitive information which should not be available on a publicly available website.', 'health-check' )
+			),
+			'actions'     => '',
+			'test'        => 'is_in_debug_mode',
+		);
+
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+				$result['label'] = esc_html__( 'Your site is set to log errors to a potentially public file.', 'health-check' );
+
+				$result['status'] = 'critical';
+
+				$result['description'] .= sprintf(
+					'<p>%s</p>',
+					esc_html__( 'The value, WP_DEBUG_LOG, has been added to this websites configuration file. This means any errors on the site will be written to a file which is potentially available to normal users.', 'health-check' )
+				);
+			}
+
+			if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
+				$result['label'] = esc_html__( 'Your site is set to display errors to site visitors.', 'health-check' );
+
+				$result['status'] = 'critical';
+
+				$result['description'] .= sprintf(
+					'<p>%s</p>',
+					esc_html__( 'The value, WP_DEBUG_DISPLAY, has either been added to your configuration file, or left with its default value. This will make errors display on the front end of your site.', 'health-check' )
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	public function json_test_is_in_debug_mode() {
+		wp_send_json_success( $this->get_test_is_in_debug_mode() );
+	}
+
 	public function get_test_https_status() {
 		$result = array(
 			'label'       => '',
@@ -1542,6 +1589,10 @@ class Health_Check_Site_Status {
 				'http_requests'     => array(
 					'label' => __( 'HTTP Requests', 'health-check' ),
 					'test'  => 'http_requests',
+				),
+				'debug_enabled'     => array(
+					'label' => __( 'Debugging enabled', 'health-check' ),
+					'test'  => 'is_in_debug_mode',
 				),
 			),
 			'async'  => array(

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -682,8 +682,9 @@ class Health_Check_Site_Status {
 				'required' => false,
 			),
 			'libsodium' => array(
-				'function' => 'sodium_compare',
-				'required' => false,
+				'function'            => 'sodium_compare',
+				'required'            => false,
+				'php_bundled_version' => '7.2.0',
 			),
 			'openssl'   => array(
 				'function' => 'openssl_encrypt',
@@ -738,7 +739,7 @@ class Health_Check_Site_Status {
 				}
 			}
 
-			if ( ! $this->child_test_php_extension_availability( $extension, $function ) ) {
+			if ( ! $this->child_test_php_extension_availability( $extension, $function ) && ( ! isset( $module['php_bundled_version'] ) || version_compare( PHP_VERSION, $modules['php_bundled_version'], '>=' ) ) ) {
 				if ( $module['required'] ) {
 					$result['status'] = 'critical';
 				}

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -106,7 +106,7 @@ class Health_Check_Site_Status {
 		);
 
 		if ( ! method_exists( $this, $function ) || ! is_callable( array( $this, $function ) ) ) {
-			die();
+			return;
 		}
 
 		$call = call_user_func( array( $this, $function ) );

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -739,7 +739,7 @@ class Health_Check_Site_Status {
 				}
 			}
 
-			if ( ! $this->child_test_php_extension_availability( $extension, $function ) && ( ! isset( $module['php_bundled_version'] ) || version_compare( PHP_VERSION, $modules['php_bundled_version'], '>=' ) ) ) {
+			if ( ! $this->child_test_php_extension_availability( $extension, $function ) && ( ! isset( $module['php_bundled_version'] ) || version_compare( PHP_VERSION, $module['php_bundled_version'], '<' ) ) ) {
 				if ( $module['required'] ) {
 					$result['status'] = 'critical';
 				}


### PR DESCRIPTION
Enhance the site status test runner:

Start by checking if a test is one of ours, if not we stop processing and return to the normal processing of WordPress, this allows any plugin or theme to also hook in and add tests that will actually run.

We also implemented the status test to check if a site is in debug mode, and if so, how errors are handled with regards to publicly disclosing them.

Fix the PHP test, where some extensions are bundled in PHP as of a given version, adding in a way to provide a bundled PHP version for wider use once other modules potentially get bundled as well.


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety