### PR TITLE
Slash URLs more reliably to avoid double-slashes

### DIFF
--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -265,9 +265,9 @@ class Health_Check {
 			}
 		}
 
-		wp_enqueue_style( 'health-check', HEALTH_CHECK_PLUGIN_URL . '/assets/css/health-check.css', array(), HEALTH_CHECK_PLUGIN_VERSION );
+		wp_enqueue_style( 'health-check', trailingslashit( HEALTH_CHECK_PLUGIN_URL ) . 'assets/css/health-check.css', array(), HEALTH_CHECK_PLUGIN_VERSION );
 
-		wp_enqueue_script( 'health-check', HEALTH_CHECK_PLUGIN_URL . '/assets/javascript/health-check.js', array( 'jquery', 'wp-a11y' ), HEALTH_CHECK_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'health-check', trailingslashit( HEALTH_CHECK_PLUGIN_URL ) . 'assets/javascript/health-check.js', array( 'jquery', 'wp-a11y' ), HEALTH_CHECK_PLUGIN_VERSION, true );
 
 		wp_localize_script( 'health-check', 'HealthCheck', $health_check_js_variables );
 	}


### PR DESCRIPTION
Make sure we don't add double-trailing slashes to the base URL for our plugin directory.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety