### PR TITLE
Run site health checks weekly in the background

### DIFF
--- a/src/health-check.php
+++ b/src/health-check.php
@@ -63,3 +63,7 @@ require_once( dirname( __FILE__ ) . '/includes/class-health-check-updates.php' )
 
 // Initialize our plugin.
 new Health_Check();
+
+// Setup up scheduled events.
+register_activation_hook( __FILE__, array( 'Health_Check', 'plugin_activation' ) );
+register_deactivation_hook( __FILE__, array( 'Health_Check', 'plugin_deactivation' ) );


### PR DESCRIPTION
Introduce a WP_Cron task to run the Site Health checks in the background once a week.

This helps populate a value so that we can indicate items that should be addressed via the admin menu badges, much in the same available updates are displayed.

This is also a requirement for #226 to be a thing in the future, but made sense to include earlier.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety