### PR TITLE
Make badges a bit more readable by adding some better margins and pad…

### DIFF
--- a/assets/sass/modules/_accordion.scss
+++ b/assets/sass/modules/_accordion.scss
@@ -59,11 +59,11 @@
 		.badge {
 
 			display: inline-block;
-			padding: 0 0.5rem;
+			padding: 0.1rem 0.5rem;
 			background-color: #dcdcdc;
 			color: #000;
 			font-weight: 600;
-			margin-left: 0.5rem;
+			margin: 0 0.5rem;
 
 			&.blue {
 


### PR DESCRIPTION
This implements slightly more readable badges by adding some better margins and paddings, and properly testing accessibility contrasts on all the default badges implemented by the plugin.

The lowest contrast value is seen at 4.53 (the `#40860a` with white, `#ffffff`, text), which passes our requirements of 4.5.

![image](https://user-images.githubusercontent.com/468735/54468963-52b67f80-4792-11e9-85b1-5355369088cb.png)


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety