### PR TITLE
Add an action for the health check page & remove meta page

### DIFF
--- a/src/health-check.php
+++ b/src/health-check.php
@@ -37,6 +37,9 @@ define( 'HEALTH_CHECK_MYSQL_REC_VERSION', '5.6' );
 // Set the plugin version.
 define( 'HEALTH_CHECK_PLUGIN_VERSION', '1.3.2' );
 
+// Set the plugin file.
+define( 'HEALTH_CHECK_PLUGIN_FILE', __FILE__ );
+
 // Set the absolute path for the plugin.
 define( 'HEALTH_CHECK_PLUGIN_DIRECTORY', plugin_dir_path( __FILE__ ) );
 

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -50,9 +50,8 @@ class Health_Check {
 
 		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
 
-		add_filter( 'plugin_row_meta', array( $this, 'settings_link' ), 10, 2 );
-
 		add_filter( 'plugin_action_links', array( $this, 'troubleshoot_plugin_action' ), 20, 4 );
+		add_filter( 'plugin_action_links_' . plugin_basename( HEALTH_CHECK_PLUGIN_FILE ), array( $this, 'page_plugin_action' ) );
 
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 
@@ -374,26 +373,6 @@ class Health_Check {
 	}
 
 	/**
-	 * Add a quick-access link under our plugin name on the plugins-list.
-	 *
-	 * @uses plugin_basename()
-	 * @uses sprintf()
-	 * @uses menu_page_url()
-	 *
-	 * @param array  $meta An array containing meta links.
-	 * @param string $name The plugin slug that these metas relate to.
-	 *
-	 * @return array
-	 */
-	public function settings_link( $meta, $name ) {
-		if ( plugin_basename( __FILE__ ) === $name ) {
-			$meta[] = sprintf( '<a href="%s">' . _x( 'Health Check', 'Menu, Section and Page Title', 'health-check' ) . '</a>', menu_page_url( 'health-check', false ) );
-		}
-
-		return $meta;
-	}
-
-	/**
 	 * Add a troubleshooting action link to plugins.
 	 *
 	 * @param $actions
@@ -436,6 +415,24 @@ class Health_Check {
 			esc_html__( 'Troubleshoot', 'health-check' )
 		);
 
+		return $actions;
+	}
+
+	/**
+	 * Add a quick-access action link to the Heath Check page.
+	 *
+	 * @param $actions
+	 *
+	 * @return array
+	 */
+	public function page_plugin_action( $actions ) {
+
+		$page_link = sprintf(
+			'<a href="%s">%s</a>',
+			menu_page_url( 'health-check', false ),
+			_x( 'Health Check', 'Menu, Section and Page Title', 'health-check' )
+		);
+		array_unshift( $actions, $page_link );
 		return $actions;
 	}
 


### PR DESCRIPTION
## Short introduction
Add a new plugin action link for the Health Check page(wp-admin/index.php?page=health-check).
Remove the not working meta link.

I prefer the action links for the setting links instead of the meta links. This preference comes from seeing other plugins doing the same. For example:
![image](https://user-images.githubusercontent.com/1785641/54496590-41d05000-48f1-11e9-989e-9d5087f9ebe3.png)


## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/1785641/54496554-f322b600-48f0-11e9-800e-ef2b2afb4328.png)
**After**
![image](https://user-images.githubusercontent.com/1785641/54496548-e30ad680-48f0-11e9-913e-9b59d10116a5.png)

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety