### PR TITLE
Add aria-label to the health check menu

### DIFF
--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -413,7 +413,7 @@ class Health_Check {
 			$current_tab = ( isset( $_GET['tab'] ) ? $_GET['tab'] : 'site-status' );
 			?>
 
-			<nav class="tabs-wrapper">
+			<nav class="tabs-wrapper" aria-label="<?php esc_attr_e( 'Secondary menu', 'health-check' ); ?>">
 				<?php
 				foreach ( $tabs as $tab => $label ) {
 					printf(


### PR DESCRIPTION
This adds an aria label to the secondary menu, denoting it as such, inside the health check area.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety