### PR TITLE
Task/replace core site health

### DIFF
--- a/assets/sass/health-check.scss
+++ b/assets/sass/health-check.scss
@@ -2,7 +2,7 @@
 
 body {
 
-	&.dashboard_page_health-check {
+	&.tools_page_health-check {
 
 		#wpcontent {
 			padding-left: 0;

--- a/src/includes/class-health-check-files-integrity.php
+++ b/src/includes/class-health-check-files-integrity.php
@@ -168,7 +168,7 @@ class Health_Check_Files_Integrity {
 	static function view_file_diff() {
 		check_ajax_referer( 'health-check-view-file-diff' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_send_json_error();
 		}
 

--- a/src/includes/class-health-check-loopback.php
+++ b/src/includes/class-health-check-loopback.php
@@ -126,7 +126,7 @@ class Health_Check_Loopback {
 	static function loopback_no_plugins() {
 		check_ajax_referer( 'health-check-loopback-no-plugins' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_send_json_error();
 		}
 
@@ -241,7 +241,7 @@ class Health_Check_Loopback {
 	static function loopback_test_individual_plugins() {
 		check_ajax_referer( 'health-check-loopback-individual-plugins' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_send_json_error();
 		}
 
@@ -292,7 +292,7 @@ class Health_Check_Loopback {
 	static function loopback_test_default_theme() {
 		check_ajax_referer( 'health-check-loopback-default-theme' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_send_json_error();
 		}
 

--- a/src/includes/class-health-check-mail-check.php
+++ b/src/includes/class-health-check-mail-check.php
@@ -29,7 +29,7 @@ class Health_Check_Mail_Check {
 	static function run_mail_check() {
 		check_ajax_referer( 'health-check-mail-check' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_send_json_error();
 		}
 

--- a/src/includes/class-health-check-site-status.php
+++ b/src/includes/class-health-check-site-status.php
@@ -90,7 +90,7 @@ class Health_Check_Site_Status {
 	public function site_status_result() {
 		check_ajax_referer( 'health-check-site-status-result' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_send_json_error();
 		}
 
@@ -100,7 +100,7 @@ class Health_Check_Site_Status {
 	public function site_status() {
 		check_ajax_referer( 'health-check-site-status' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_send_json_error();
 		}
 

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -85,7 +85,7 @@ class Health_Check {
 	 * @return void
 	 */
 	public function start_troubleshoot_mode() {
-		if ( ! isset( $_POST['health-check-troubleshoot-mode'] ) || ! current_user_can( 'manage_options' ) ) {
+		if ( ! isset( $_POST['health-check-troubleshoot-mode'] ) || ! current_user_can( 'install_plugins' ) ) {
 			return;
 		}
 
@@ -117,7 +117,7 @@ class Health_Check {
 	 * @return void
 	 */
 	public function start_troubleshoot_single_plugin_mode() {
-		if ( ! isset( $_GET['health-check-troubleshoot-plugin'] ) || ! current_user_can( 'manage_options' ) ) {
+		if ( ! isset( $_GET['health-check-troubleshoot-plugin'] ) || ! current_user_can( 'install_plugins' ) ) {
 			return;
 		}
 
@@ -330,7 +330,7 @@ class Health_Check {
 		add_dashboard_page(
 			_x( 'Site Health', 'Page Title', 'health-check' ),
 			$menu_title,
-			'manage_options',
+			'install_plugins',
 			'health-check',
 			array( $this, 'dashboard_page' )
 		);

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -327,7 +327,10 @@ class Health_Check {
 				( ! $issue_counts || $critical_issues < 1 ? '' : $critical_count )
 			);
 
-		add_dashboard_page(
+		remove_submenu_page( 'tools.php', 'site-health.php' );
+
+		add_submenu_page(
+			'tools.php',
 			_x( 'Site Health', 'Page Title', 'health-check' ),
 			$menu_title,
 			'install_plugins',


### PR DESCRIPTION
As WordPress 5.2 introduces the Site Health Check module, we need to remove that and replace with the plugin version when applicable.