### PR TITLE
Add required fallback for ClipboardJS

### DIFF
--- a/docs/plugin/readme.txt
+++ b/docs/plugin/readme.txt
@@ -3,7 +3,7 @@ Tags: health check
 Contributors: wordpressdotorg, westi, pento, Clorith
 Requires at least: 4.0
 Tested up to: 5.2
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,9 @@ Are you unfamiliar with how to clear your cookies? No worries, you may also clos
 3. The generic PHP information tab, when more detailed information is required.
 
 == Changelog ==
+
+= v1.3.1 =
+* Include missing dependency for JavaScript files, first introduced in WordPress 5.2
 
 = v1.3.0 =
 * Plugin moved to the Tools section in the admin menu

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -73,6 +73,12 @@ module.exports = function( grunt ) {
 				src: [ '**/*', '!assets/*' ],
 				dest: 'build/',
 				expand: true
+			},
+			dependencies: {
+				cwd: 'node_modules/clipboard/dist/',
+				src: [ '**/*.min.js' ],
+				dest: 'build/assets/javascript/',
+				expand: true
 			}
 		},
 		jscs: {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.3.0",
     "autoprefixer": "^7.1.2",
+    "clipboard": "^2.0.4",
     "grunt": "~1.0.1",
     "grunt-check-dependencies": "~1.0.0",
     "grunt-checktextdomain": "~1.0.1",

--- a/src/health-check.php
+++ b/src/health-check.php
@@ -9,7 +9,7 @@
  * Plugin URI: https://wordpress.org/plugins/health-check/
  * Description: Checks the health of your WordPress install.
  * Author: The WordPress.org community
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author URI: https://wordpress.org/plugins/health-check/
  * Text Domain: health-check
  */
@@ -35,7 +35,7 @@ define( 'HEALTH_CHECK_MYSQL_MIN_VERSION', '5.0' );
 define( 'HEALTH_CHECK_MYSQL_REC_VERSION', '5.6' );
 
 // Set the plugin version.
-define( 'HEALTH_CHECK_PLUGIN_VERSION', '1.3.0' );
+define( 'HEALTH_CHECK_PLUGIN_VERSION', '1.3.1' );
 
 // Set the absolute path for the plugin.
 define( 'HEALTH_CHECK_PLUGIN_DIRECTORY', plugin_dir_path( __FILE__ ) );

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -285,6 +285,10 @@ class Health_Check {
 			}
 		}
 
+		if ( ! wp_script_is( 'clipboard', 'registered' ) ) {
+			wp_register_script( 'clipboard', trailingslashit( HEALTH_CHECK_PLUGIN_URL ) . 'assets/javascript/clipboard.min.js', array(), '2.0.4' );
+		}
+
 		wp_enqueue_style( 'health-check', trailingslashit( HEALTH_CHECK_PLUGIN_URL ) . 'assets/css/health-check.css', array(), HEALTH_CHECK_PLUGIN_VERSION );
 
 		wp_enqueue_script( 'health-check', trailingslashit( HEALTH_CHECK_PLUGIN_URL ) . 'assets/javascript/health-check.js', array( 'jquery', 'wp-a11y', 'clipboard', 'wp-util' ), HEALTH_CHECK_PLUGIN_VERSION, true );


### PR DESCRIPTION
Turns out, ClipboardJS doesn't exist in core until 5.2, who knew, not me!

This pushes a fallback version to the plugin which will only be used if core (or any other code) hasn't already registered the clipboard handler.