### PR TITLE
Fix action links in Plugins page

### DIFF
--- a/src/assets/mu-plugin/health-check-troubleshooting-mode.php
+++ b/src/assets/mu-plugin/health-check-troubleshooting-mode.php
@@ -228,10 +228,11 @@ class Health_Check_Troubleshooting_MU {
 
 		// Set a slug if the plugin lives in the plugins directory root.
 		if ( ! stristr( $plugin_file, '/' ) ) {
-			$plugin_data['slug'] = $plugin_file;
+			$plugin_slug = $plugin_file;
+		} else { // Set the slug for plugin inside a folder.
+			$plugin_slug = explode( '/', $plugin_file );
+			$plugin_slug = $plugin_slug[0];
 		}
-
-		$plugin_slug = ( isset( $plugin_data['slug'] ) ? $plugin_data['slug'] : sanitize_title( $plugin_data['Name'] ) );
 
 		if ( in_array( $plugin_slug, $this->allowed_plugins ) ) {
 			$actions['troubleshoot-disable'] = sprintf(

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -387,17 +387,17 @@ class Health_Check {
 
 		// Set a slug if the plugin lives in the plugins directory root.
 		if ( ! stristr( $plugin_file, '/' ) ) {
-			$plugin_data['slug'] = $plugin_file;
+			$plugin_slug = $plugin_file;
+		} else { // Set the slug for plugin inside a folder.
+			$plugin_slug = explode( '/', $plugin_file );
+			$plugin_slug = $plugin_slug[0];
 		}
-
-		// If a slug isn't present, use the plugin's name
-		$plugin_name = ( isset( $plugin_data['slug'] ) ? $plugin_data['slug'] : sanitize_title( $plugin_data['Name'] ) );
 
 		$actions['troubleshoot'] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( add_query_arg( array(
-				'health-check-troubleshoot-plugin' => $plugin_name,
-				'_wpnonce'                         => wp_create_nonce( 'health-check-troubleshoot-plugin-' . $plugin_name ),
+				'health-check-troubleshoot-plugin' => $plugin_slug,
+				'_wpnonce'                         => wp_create_nonce( 'health-check-troubleshoot-plugin-' . $plugin_slug ),
 			), admin_url( 'plugins.php' ) ) ),
 			esc_html__( 'Troubleshoot', 'health-check' )
 		);


### PR DESCRIPTION
## Short introduction
Actions links in the Plugins page are not working for plugins with names not being exactly the same than the plugin slug (e.g. A plugin with spaces in the name but living inside of a folder without hyphens).

This is a pretty common scenario for plugins with large names or renamed after being published in WordPress.org

## Description of what the PR accomplishes
$plugin_slug is correctly set in health_check_troubleshoot_menu_bar() and also in display_dashboard_widget() based on slugs stored in $this->active_plugins

plugin_actions() and troubleshoot_plugin_action() functions are using a different approach using $plugin_file for plugins living in wp-content/plugins/ root (this is correct), but incorrently assuming $plugin_data['Name'] it's always the same than the plugin slug for any plugin living in a folder (most common scenario).

It's pretty common to see plugins using a plugin name larger than the folder name (like Health Check & Troubleshooting does), or using spaces in the plugin name while not using hyphens in the folder, it's also very common to see renamed plugins in the WordPress.org repository. The repo allows you to change the name, but the slug can't be modified.

Therefore assuming $plugin_data['Name'] can be used for $plugin_slug is a bad idea.

This pull request fixes the issue using $plugin_file to get the correct value for $plugin_slug also for plugins living in their own folder, the most common scenario. That is basically the same that the other functions do using $this->active_plugins, so it also adds consistency to the way the plugin slug is obtained across different functions in the plugin.

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety