### PR TITLE
Modify site health grading visuals and calculations

### DIFF
--- a/assets/javascript/site-status/site-status-tests.js
+++ b/assets/javascript/site-status/site-status-tests.js
@@ -50,10 +50,11 @@ jQuery( document ).ready(function( $ ) {
 	function RecalculateProgression() {
 		var r, c, pct;
 		var $progress = $( '.site-health-progress' );
-		var $progressCount = $progress.find( '.site-health-progress-count' );
+		var $wrapper = $progress.closest( '.site-health-progress-wrapper' );
+		var $progressLabel = $( '.site-health-progress-label', $wrapper );
 		var $circle = $( '.site-health-progress svg #bar' );
 		var totalTests = parseInt( SiteHealth.site_status.issues.good, 0 ) + parseInt( SiteHealth.site_status.issues.recommended, 0 ) + ( parseInt( SiteHealth.site_status.issues.critical, 0 ) * 1.5 );
-		var failedTests = parseInt( SiteHealth.site_status.issues.recommended, 0 ) + ( parseInt( SiteHealth.site_status.issues.critical, 0 ) * 1.5 );
+		var failedTests = ( parseInt( SiteHealth.site_status.issues.recommended, 0 ) * 0.5 ) + ( parseInt( SiteHealth.site_status.issues.critical, 0 ) * 1.5 );
 		var val = 100 - Math.ceil( ( failedTests / totalTests ) * 100 );
 
 		if ( 0 === totalTests ) {
@@ -61,7 +62,7 @@ jQuery( document ).ready(function( $ ) {
 			return;
 		}
 
-		$progress.removeClass( 'loading' );
+		$wrapper.removeClass( 'loading' );
 
 		r = $circle.attr( 'r' );
 		c = Math.PI * ( r * 2 );
@@ -85,21 +86,6 @@ jQuery( document ).ready(function( $ ) {
 			$( '#health-check-issues-recommended' ).addClass( 'hidden' );
 		}
 
-		if ( 50 <= val ) {
-			$circle.addClass( 'orange' ).removeClass( 'red' );
-		}
-
-		if ( 90 <= val ) {
-			$circle.addClass( 'green' ).removeClass( 'orange' );
-		}
-
-		if ( 100 === val ) {
-			$( '.site-status-all-clear' ).removeClass( 'hide' );
-			$( '.site-status-has-issues' ).addClass( 'hide' );
-		}
-
-		$progressCount.text( val + '%' );
-
 		if ( ! isDebugTab ) {
 			$.post(
 				ajaxurl,
@@ -111,7 +97,22 @@ jQuery( document ).ready(function( $ ) {
 			);
 		}
 
-		wp.a11y.speak( SiteHealth.string.site_health_complete_screen_reader.replace( '%s', val + '%' ) );
+		if ( 80 <= val && 0 === parseInt( SiteHealth.site_status.issues.critical, 0 ) ) {
+			$wrapper.addClass( 'green' ).removeClass( 'orange' );
+
+			$progressLabel.text( SiteHealth.string.site_health_complete_pass );
+			wp.a11y.speak( SiteHealth.string.site_health_complete_pass_sr );
+		} else {
+			$wrapper.addClass( 'orange' ).removeClass( 'green' );
+
+			$progressLabel.text( SiteHealth.string.site_health_complete_fail );
+			wp.a11y.speak( SiteHealth.string.site_health_complete_fail_sr );
+		}
+
+		if ( 100 === val ) {
+			$( '.site-status-all-clear' ).removeClass( 'hide' );
+			$( '.site-status-has-issues' ).addClass( 'hide' );
+		}
 	}
 
 	function maybeRunNextAsyncTest() {

--- a/assets/sass/health-check.scss
+++ b/assets/sass/health-check.scss
@@ -81,87 +81,28 @@ body {
 					display: inline-block;
 					font-weight: 600;
 					font-size: $font_size__h1;
-					margin: 1rem 0.8rem;
+					margin: 0 0.8rem 1rem;
 					padding: 9px 0 4px;
 					line-height: 1.3;
 					font-family: $font_family__h1;
 				}
 
-				.site-health-progress {
+				&.site-health-progress-wrapper {
 
-					display: inline-block;
-					height: 40px;
-					width: 40px;
-					margin: 0;
-					border-radius: 100%;
-					position: relative;
-					font-weight: 600;
-					font-size: 0.4rem;
+					margin-bottom: 1rem;
 
 					&.loading {
 
-						.site-health-progress-count {
+						.site-health-progress {
 
-							&:after {
+							svg {
 
-								content: "···";
-							}
-						}
+								#bar {
 
-						svg {
-
-							#bar {
-
-								stroke-dashoffset: 0;
-								stroke: #adc5d2;
-								animation: loadingPulse 3s infinite ease-in-out;
-							}
-						}
-					}
-
-					.site-health-progress-count {
-
-						position: absolute;
-						display: block;
-						height: 80px;
-						width: 80px;
-						left: 50%;
-						top: 50%;
-						margin-top: -40px;
-						margin-left: -40px;
-						border-radius: 100%;
-						line-height: 6.3;
-						font-size: 2em;
-
-						&:after {
-
-							content: "";
-						}
-					}
-
-					svg {
-
-						circle {
-
-							stroke-dashoffset: 0;
-							transition: stroke-dashoffset 1s linear;
-							stroke: #ccc;
-							stroke-width: 2em;
-						}
-
-						#bar {
-
-							stroke-dashoffset: 565;
-							stroke: #dc3232;
-
-							&.green {
-
-								stroke: #46b450;
-							}
-
-							&.orange {
-
-								stroke: #ffb900;
+									stroke-dashoffset: 0;
+									stroke: #adc5d2;
+									animation: loadingPulse 3s infinite ease-in-out;
+								}
 							}
 						}
 					}
@@ -183,6 +124,67 @@ body {
 							stroke: #adc5d2;
 
 						}
+					}
+
+					&.green {
+
+						#bar {
+
+							stroke: #46b450;
+						}
+
+						.site-health-progress-label {
+
+							color: #46b450;
+						}
+					}
+
+					&.orange {
+
+						#bar {
+
+							stroke: #ffb900;
+						}
+
+						.site-health-progress-label {
+
+							color: #ffb900;
+						}
+					}
+
+					.site-health-progress {
+
+						display: inline-block;
+						height: 20px;
+						width: 20px;
+						margin: 0;
+						border-radius: 100%;
+						position: relative;
+						font-weight: 600;
+						font-size: 0.4rem;
+
+						svg {
+
+							circle {
+
+								stroke-dashoffset: 0;
+								transition: stroke-dashoffset 1s linear;
+								stroke: #ccc;
+								stroke-width: 3em;
+							}
+
+							#bar {
+
+								stroke-dashoffset: 565;
+							}
+						}
+					}
+
+					.site-health-progress-label {
+
+						font-weight: 600;
+						line-height: 20px;
+						margin-left: 0.3rem;
 					}
 				}
 			}

--- a/src/includes/class-health-check.php
+++ b/src/includes/class-health-check.php
@@ -232,10 +232,10 @@ class Health_Check {
 				'copied'                               => esc_html__( 'Copied', 'health-check' ),
 				'running_tests'                        => esc_html__( 'Currently being tested...', 'health-check' ),
 				'site_health_complete'                 => esc_html__( 'All site health tests have finished running.', 'health-check' ),
-				'site_info_show_copy'                  => esc_html__( 'Show options for copying this information', 'health-check' ),
-				'site_info_hide_copy'                  => esc_html__( 'Hide options for copying this information', 'health-check' ),
-				// translators: %s: The percentage pass rate for the tests.
-				'site_health_complete_screen_reader'   => esc_html__( 'All site health tests have finished running. Your site passed %s, and the results are now available on the page.', 'health-check' ),
+				'site_health_complete_pass_sr'         => esc_html__( 'All site health tests have finished running. Your site is looking good, and the results are now available on the page.', 'health-check' ),
+				'site_health_complete_fail_sr'         => esc_html__( 'All site health tests have finished running. There are items that should be addressed, and the results are now available on the page.', 'health-check' ),
+				'site_health_complete_pass'            => esc_html__( 'Good', 'health-check' ),
+				'site_health_complete_fail'            => esc_html__( 'Should be improved', 'health-check' ),
 				'site_info_copied'                     => esc_html__( 'Site information has been added to your clipboard.', 'health-check' ),
 				// translators: %s: Amount of critical issues.
 				'site_info_heading_critical_single'    => esc_html__( '%s Critical issue', 'health-check' ),

--- a/src/pages/site-health-header.php
+++ b/src/pages/site-health-header.php
@@ -16,14 +16,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<h1>
 			<?php esc_html_e( 'Site Health', 'health-check' ); ?>
 		</h1>
+	</div>
 
-		<div class="site-health-progress hide-if-no-js loading">
+	<div class="health-check-title-section site-health-progress-wrapper loading hide-if-no-js">
+		<div class="site-health-progress">
 			<svg role="img" aria-hidden="true" focusable="false" width="100%" height="100%" viewBox="0 0 200 200" version="1.1" xmlns="http://www.w3.org/2000/svg">
 				<circle r="90" cx="100" cy="100" fill="transparent" stroke-dasharray="565.48" stroke-dashoffset="0"></circle>
 				<circle id="bar" r="90" cx="100" cy="100" fill="transparent" stroke-dasharray="565.48" stroke-dashoffset="0"></circle>
 			</svg>
-			<span class="screen-reader-text"><?php _e( 'Current completion rate:', 'health-check' ); ?></span>
-			<span class="site-health-progress-count"></span>
+		</div>
+		<div class="site-health-progress-label">
+			<?php _e( 'Results are still loading&hellip;', 'health-check' ); ?>
 		</div>
 	</div>
 


### PR DESCRIPTION
See #342 for the discussion on this.

Modify the grading indicator for the Site Health Check feature, removing the current numeric indicators, and instead use a term-based output, this avoids over-thinking the percentage score which some users may find to be a stressfull element, while still retaining an indicator that there's items that can be improved.

This also improves on the lodaing indicator, providing an actual text string to indicate to users that the process is still loading, which may not have been apparent when it was just a single pulsating icon at the top.

Let's get this rolling in the plugin to gauge the impact, before we push the changes for core it self.

## Screenshots
![new-grading](https://user-images.githubusercontent.com/468735/60290252-a7809f00-9918-11e9-90a7-8334b8653854.gif)


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety