### PR TITLE
Fix travis failing PHPUnit

### DIFF
--- a/src/includes/compat.php
+++ b/src/includes/compat.php
@@ -1,9 +1,9 @@
 <?php
 
 // Manually include the versions file as we can't always rely on `get_bloginfo()` to fetch versions.
-include_once( ABSPATH . '/wp-includes/version.php' );
+include ABSPATH . WPINC . '/version.php';
 
-if ( ! function_exists( 'wp_check_php_version' ) && version_compare( '5.1.0', $wp_version, '>' ) ) {
+if ( ! function_exists( 'wp_check_php_version' ) && version_compare( '5.1', $wp_version, '>' ) ) {
 	/**
 	 * Fallback function replicating core behavior from WordPress 5.1.0 to check PHP versions.
 	 *
@@ -65,7 +65,7 @@ if ( ! function_exists( 'wp_check_php_version' ) && version_compare( '5.1.0', $w
 	}
 }
 
-if ( ! function_exists( 'wp_get_update_php_url' ) && version_compare( '5.1.0', $wp_version, '>' ) ) {
+if ( ! function_exists( 'wp_get_update_php_url' ) && version_compare( '5.1', $wp_version, '>' ) ) {
 	/**
 	 * Fallback function replicating core behavior from WordPress 5.1.0 to check PHP versions.
 	 *
@@ -121,7 +121,7 @@ if ( ! function_exists( 'is_countable' ) && version_compare( '4.9.6', $wp_versio
 	}
 }
 
-if ( ! function_exists( 'get_user_count' ) && version_compare( '4.8.0', $wp_version, '>' ) ) {
+if ( ! function_exists( 'get_user_count' ) && version_compare( '4.8', $wp_version, '>' ) ) {
 	/**
 	 * Fallback function replicating core behavior from WordPress 4.8.0 to check PHP versions.
 	 *
@@ -132,7 +132,7 @@ if ( ! function_exists( 'get_user_count' ) && version_compare( '4.8.0', $wp_vers
 	}
 }
 
-if ( ! function_exists( 'get_user_locale' ) && version_compare( '4.7.0', $wp_version, '>' ) ) {
+if ( ! function_exists( 'get_user_locale' ) && version_compare( '4.7', $wp_version, '>' ) ) {
 	/**
 	 * Fallback function replicating core behavior from WordPress 4.7.0 to check PHP versions.
 	 *
@@ -157,7 +157,7 @@ if ( ! function_exists( 'get_user_locale' ) && version_compare( '4.7.0', $wp_ver
 	}
 }
 
-if ( ! function_exists( 'wp_get_upload_dir' ) && version_compare( '4.5.0', $wp_version, '>' ) ) {
+if ( ! function_exists( 'wp_get_upload_dir' ) && version_compare( '4.5', $wp_version, '>' ) ) {
 	/**
 	 * Fallback function replicating core behavior from WordPress 4.5.0 to check PHP versions.
 	 *


### PR DESCRIPTION
## Short introduction
The Travis build was failing because of the following error in PHPUnit.

```
PHP Notice:  Undefined variable: wp_version in /home/travis/build/WordPress/health-check/src/includes/compat.php on line 6
Notice: Undefined variable: wp_version in /home/travis/build/WordPress/health-check/src/includes/compat.php on line 124
Fatal error: Cannot redeclare wp_check_php_version() (previously declared in /home/travis/build/WordPress/health-check/src/includes/compat.php:13) in /tmp/wordpress/wp-admin/includes/misc.php on line 2096
```

This PR fixes that.

## Description of what the PR accomplishes
The changes made are:
- Change the values of the version to ones without a trailing zero.
```php
version_compare( '5.1.0', '5.1', '>' ) // returns true ❌
version_compare( '5.1', '5.1.0', '>' ) // returns false ✅
version_compare( '5.1', '5.0', '>' ) // returns true  ✅
```
- Use the constant for the wp-includes folder
- Change include instead of include_once as we want to the file to be loaded for the compact.php file. The version.php contains variables with the current versions so can be loaded multiple times.
- Better to use include as statement instead of a function for performance

## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety