### PR TITLE
Fix treating callable array as string

### DIFF
--- a/src/php/includes/class-health-check-site-status.php
+++ b/src/php/includes/class-health-check-site-status.php
@@ -2009,7 +2009,7 @@ class Health_Check_Site_Status {
 		$tests = array_merge( $bulk_tests['direct'], $bulk_tests['async'] );
 
 		foreach ( $tests as $test ) {
-			if( is_array( $test['test'] ) && is_callable( $test['test'] ) ) {
+			if ( is_array( $test['test'] ) && is_callable( $test['test'] ) ) {
 				$results[] = call_user_func( $test['test'] );
 			} else {
 				$function = sprintf(

--- a/src/php/includes/class-health-check-site-status.php
+++ b/src/php/includes/class-health-check-site-status.php
@@ -2009,15 +2009,17 @@ class Health_Check_Site_Status {
 		$tests = array_merge( $bulk_tests['direct'], $bulk_tests['async'] );
 
 		foreach ( $tests as $test ) {
-			$function = sprintf(
-				'get_test_%s',
-				$test['test']
-			);
-
-			if ( method_exists( $this, $function ) && is_callable( array( $this, $function ) ) ) {
-				$results[] = call_user_func( array( $this, $function ) );
-			} else {
+			if( is_array( $test['test'] ) && is_callable( $test['test'] ) ) {
 				$results[] = call_user_func( $test['test'] );
+			} else {
+				$function = sprintf(
+					'get_test_%s',
+					$test['test']
+				);
+
+				if ( method_exists( $this, $function ) && is_callable( array( $this, $function ) ) ) {
+					$results[] = call_user_func( array( $this, $function ) );
+				}
 			}
 		}
 


### PR DESCRIPTION
## Short introduction
Initially posted in #384 , health test data exists as either an array-based callable or a string, but cron invoking assumes the latter

## Description of what the PR accomplishes
The [health test data](https://github.com/WordPress/health-check/blob/3fee540621879cacac3e14dcc486ce606d24861a/src/includes/class-health-check-site-status.php#L1878) exists as either a callable using array syntax, or a string that gets prepended with `get_test_`. The [cron job](https://github.com/WordPress/health-check/blob/3fee540621879cacac3e14dcc486ce606d24861a/src/includes/class-health-check-site-status.php#L1995) that actually runs this code, however, first blindly assumes that it is a string and uses it as such in a `sprintf` statement which raises a notice:

  > PHP Notice:  Array to string conversion in wp-content\plugins\health-check\includes\class-health-check-site-status.php on line 2014

This PR fixes the logic to check if the current test is a callable array and if so, use it, and then falls back to the original logic.

To reproduce the bug, install and activate the plugin on a regular WP site (tested against WP 5.5.1 running PHP 7.4.2) and try manually running all cron jobs:

```
wp cron event run --all
```

## Screenshots
n/a


## PR Checklist
These are things to ensure are covered by your PR.
- [x] This PR is created against the `develop` branch
- [x] This PR is feature ready and can be reviewed in its entirety