### PR TITLE
check if $core_updates is an array before iterating on it

### DIFF
--- a/src/includes/class-health-check-debug-data.php
+++ b/src/includes/class-health-check-debug-data.php
@@ -56,12 +56,14 @@ class Health_Check_Debug_Data {
 		$core_updates           = get_core_updates();
 		$core_update_needed     = '';
 
-		foreach ( $core_updates as $core => $update ) {
-			if ( 'upgrade' === $update->response ) {
-				// translators: %s: Latest WordPress version number.
-				$core_update_needed = ' ' . sprintf( __( '(Latest version: %s)', 'health-check' ), $update->version );
-			} else {
-				$core_update_needed = '';
+		if ( is_array( $core_updates ) ) {
+			foreach ( $core_updates as $core => $update ) {
+				if ( 'upgrade' === $update->response ) {
+					// translators: %s: Latest WordPress version number.
+					$core_update_needed = ' ' . sprintf( __( '(Latest version: %s)', 'health-check' ), $update->version );
+				} else {
+					$core_update_needed = '';
+				}
 			}
 		}
 


### PR DESCRIPTION
## Short introduction
fixes #388
check if $core_updates is an array before iterating on it

## Description of what the PR accomplishes
Avoids `Warning: Invalid argument supplied for foreach()`
