### PR TITLE
Remove old transients when the plugin is removed

### DIFF
--- a/src/php/uninstall.php
+++ b/src/php/uninstall.php
@@ -30,7 +30,7 @@ $wpdb->delete(
 );
 
 // Remove any transients and similar which the plugin may have left behind.
-$wpdb->query( "DELETE FROM {$wpdb->options} WHERE `option_name` LIKE '_transient_%_health-check%'" );
+$wpdb->query( "DELETE FROM {$wpdb->options} WHERE `option_name` LIKE '_transient_health-check%'" );
 
 // Remove the old Must-Use plugin if it was implemented.
 if ( file_exists( trailingslashit( WPMU_PLUGIN_DIR ) . 'health-check-disable-plugins.php' ) ) {


### PR DESCRIPTION
## Short introduction
Remove old transients when the plugin is removed
Currently, after the uninstall, the transients still exists due to regex not catching `health-check` plugin transients
Here is the SQL query after the plugin uninstall:
![download (1)](https://user-images.githubusercontent.com/16621855/167144250-04cb5168-4549-4253-b2b5-2e328540de8b.png)


## Description of what the PR accomplishes
Fixes transients removal SQL query