### PR TITLE
Health_Check_Debug_Log_Viewer: Avoid OOM errors because of large log files

### DIFF
--- a/HealthCheck/Tools/class-health-check-debug-log-viewer.php
+++ b/HealthCheck/Tools/class-health-check-debug-log-viewer.php
@@ -28,7 +28,16 @@ class Health_Check_Debug_Log_Viewer extends Health_Check_Tool {
 			return '';
 		}
 
-		$debug_log = @file_get_contents( $logfile );
+		if ( ! is_readable( $logfile ) ) {
+			return sprintf(
+				// translators: %s: The path to the debug log file.
+				__( 'The debug log file found at `%s`, could not be read.', 'health-check' ),
+				$logfile
+			);
+		}
+
+		// Only read the last 200k of the log file to avoid Oout of memory errors.
+		$debug_log = file_get_contents( $logfile, null, null, max( 0, filesize( $logfile ) - 200000 ) );
 
 		if ( false === $debug_log ) {
 			return sprintf(


### PR DESCRIPTION
## Short introduction
- This fixes out of memory errors when you have a large logfile in WP_DEBUG_LOG and you visit `site-health.php?tab=tools`, for example:
```
PHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 456622416 bytes) in wp-includes/formatting.php on line 4720
```

## Description of what the PR accomplishes
- Instead of reading the whole log file, only read the last 200k which should give plenty of data.
