### PR TITLE
Move all i18n calls to init action as per WP 6.7

### DIFF
--- a/HealthCheck/class-health-check.php
+++ b/HealthCheck/class-health-check.php
@@ -46,7 +46,7 @@ class Health_Check {
 	 * @return void
 	 */
 	public function init() {
-		add_action( 'plugins_loaded', array( $this, 'load_i18n' ) );
+		add_action( 'init', array( $this, 'load_i18n' ) );
 
 		add_filter( 'plugin_action_links', array( $this, 'troubleshoot_plugin_action' ), 20, 4 );
 		add_filter( 'plugin_action_links_' . plugin_basename( HEALTH_CHECK_PLUGIN_FILE ), array( $this, 'page_plugin_action' ) );

--- a/health-check.php
+++ b/health-check.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'WP_Debug_Data' ) ) {
 }
 
 add_action(
-	'plugins_loaded',
+	'init',
 	function() {
 		// Include class-files used by our plugin.
 		require_once( dirname( __FILE__ ) . '/HealthCheck/class-health-check.php' );


### PR DESCRIPTION
See #477

## Short introduction
Ticket #477 

Remove warnings related to i18n in WordPress 6.7

## Description of what the PR accomplishes
This PR removes the warnings for WordPress 6.7 in regards to calling i18n functions before `init` hook.
The problem is not only on the `load_plugin_textdomain` call but also in any call to a i18n function before `init` action.

This commit moves the requires to `init`. Manual tests were made using this hook level and no issues were found.