### PR TITLE
Fixes WordPress 6.7 warning about loading translations too early

### DIFF
--- a/HealthCheck/Tools/class-health-check-beta-features.php
+++ b/HealthCheck/Tools/class-health-check-beta-features.php
@@ -16,13 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Health_Check_Beta_Features extends Health_Check_Tool {
 
-	public function __construct() {
-		$this->label       = __( 'Beta features', 'health-check' );
-		$this->description = __( 'The plugin may contain beta features, which you as the site owner can enable or disable as you wish.', 'health-check' );
 
+	public function __construct() {
 		parent::__construct();
 
 		add_action( 'admin_init', array( $this, 'toggle_beta_features' ) );
+	}
+
+	public function set_description() {
+		$this->label       = __( 'Beta features', 'health-check' );
+		$this->description = __( 'The plugin may contain beta features, which you as the site owner can enable or disable as you wish.', 'health-check' );
 	}
 
 	public function toggle_beta_features() {

--- a/HealthCheck/Tools/class-health-check-debug-log-viewer.php
+++ b/HealthCheck/Tools/class-health-check-debug-log-viewer.php
@@ -2,11 +2,9 @@
 
 class Health_Check_Debug_Log_Viewer extends Health_Check_Tool {
 
-	public function __construct() {
+	public function set_description() {
 		$this->label       = __( 'Debug logs', 'health-check' );
 		$this->description = __( 'The details below are gathered from your <code>debug.log</code> file, and is displayed because the <code>WP_DEBUG_LOG</code> constant has been set to allow logging of warnings and errors.', 'health-check' );
-
-		parent::__construct();
 	}
 
 	private function read_debug_log() {

--- a/HealthCheck/Tools/class-health-check-files-integrity.php
+++ b/HealthCheck/Tools/class-health-check-files-integrity.php
@@ -17,13 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Health_Check_Files_Integrity extends Health_Check_Tool {
 
 	public function __construct() {
-		$this->label       = __( 'File integrity', 'health-check' );
-		$this->description = __( 'The File Integrity checks all the core files with the <code>checksums</code> provided by the WordPress API to see if they are intact. If there are changes you will be able to make a Diff between the files hosted on WordPress.org and your installation to see what has been changed.', 'health-check' );
 
 		add_action( 'wp_ajax_health-check-files-integrity-check', array( $this, 'run_files_integrity_check' ) );
 		add_action( 'wp_ajax_health-check-view-file-diff', array( $this, 'view_file_diff' ) );
 
 		parent::__construct();
+	}
+
+	public function set_description() {
+		$this->label       = __( 'File integrity', 'health-check' );
+		$this->description = __( 'The File Integrity checks all the core files with the <code>checksums</code> provided by the WordPress API to see if they are intact. If there are changes you will be able to make a Diff between the files hosted on WordPress.org and your installation to see what has been changed.', 'health-check' );
 	}
 
 	/**

--- a/HealthCheck/Tools/class-health-check-htaccess.php
+++ b/HealthCheck/Tools/class-health-check-htaccess.php
@@ -16,11 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Health_Check_Htaccess extends Health_Check_Tool {
 
-	public function __construct() {
+	public function set_description() {
 		$this->label       = __( '.htaccess Viewer', 'health-check' );
 		$this->description = __( 'The <code>.htaccess</code> file tells your server (if supported) how to handle links and file requests. This file usually requires direct server access to view, but if your system supports these files, you can verify its content here.', 'health-check' );
-
-		parent::__construct();
 	}
 
 	public function tab_content() {

--- a/HealthCheck/Tools/class-health-check-mail-check.php
+++ b/HealthCheck/Tools/class-health-check-mail-check.php
@@ -19,12 +19,14 @@ class Health_Check_Mail_Check extends Health_Check_Tool {
 	private $mail_error = null;
 
 	public function __construct() {
-		$this->label       = __( 'Mail Check', 'health-check' );
-		$this->description = __( 'The Mail Check will invoke the <code>wp_mail()</code> function and check if it succeeds. We will use the E-mail address you have set up, but you can change it below if you like.', 'health-check' );
-
 		add_action( 'wp_ajax_health-check-mail-check', array( $this, 'run_mail_check' ) );
 
 		parent::__construct();
+	}
+
+	public function set_description() {
+		$this->label       = __( 'Mail Check', 'health-check' );
+		$this->description = __( 'The Mail Check will invoke the <code>wp_mail()</code> function and check if it succeeds. We will use the E-mail address you have set up, but you can change it below if you like.', 'health-check' );
 	}
 
 	/**

--- a/HealthCheck/Tools/class-health-check-phpinfo.php
+++ b/HealthCheck/Tools/class-health-check-phpinfo.php
@@ -16,6 +16,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Health_Check_Phpinfo extends Health_Check_Tool {
 
 	public function __construct() {
+		add_action( 'site_health_tab_content', array( $this, 'add_site_health_tab_content' ) );
+
+		parent::__construct();
+	}
+
+	public function set_description() {
 		$this->label = __( 'PHP Info', 'health-check' );
 
 		if ( ! function_exists( 'phpinfo' ) ) {
@@ -23,10 +29,6 @@ class Health_Check_Phpinfo extends Health_Check_Tool {
 		} else {
 			$this->description = __( 'Some scenarios require you to look up more detailed server configurations than what is normally required. The PHP Info page allows you to view all available configuration options for your PHP setup. Please be advised that WordPress does not guarantee that any information shown on that page may not be considered sensitive.', 'health-check' );
 		}
-
-		add_action( 'site_health_tab_content', array( $this, 'add_site_health_tab_content' ) );
-
-		parent::__construct();
 	}
 
 	/**

--- a/HealthCheck/Tools/class-health-check-plugin-compatibility.php
+++ b/HealthCheck/Tools/class-health-check-plugin-compatibility.php
@@ -3,6 +3,12 @@
 class Health_Check_Plugin_Compatibility extends Health_Check_Tool {
 
 	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_plugin_compat_rest_route' ) );
+
+		parent::__construct();
+	}
+
+	public function set_description() {
 		$this->label       = __( 'Plugin compatibility', 'health-check' );
 		$this->description = sprintf(
 			'%s<br>%s',
@@ -10,9 +16,6 @@ class Health_Check_Plugin_Compatibility extends Health_Check_Tool {
 			__( 'The compatibility check will need to send requests to the <a href="https://wptide.org">WPTide</a> project to fetch the test results for each of your plugins.', 'health-check' )
 		);
 
-		add_action( 'rest_api_init', array( $this, 'register_plugin_compat_rest_route' ) );
-
-		parent::__construct();
 	}
 
 	public function register_plugin_compat_rest_route() {

--- a/HealthCheck/Tools/class-health-check-robotstxt.php
+++ b/HealthCheck/Tools/class-health-check-robotstxt.php
@@ -16,11 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Health_Check_Robotstxt extends Health_Check_Tool {
 
-	public function __construct() {
+	public function set_description() {
 		$this->label       = __( 'robots.txt Viewer', 'health-check' );
 		$this->description = __( 'The <code>robots.txt</code> file tells search engines which directories are allowed to be crawled and which not. WordPress generates a virtual file if there is no physical file. If there is a non-virtual file, the content will be displayed here.', 'health-check' );
-
-		parent::__construct();
 	}
 
 	public function tab_content() {

--- a/HealthCheck/Tools/class-health-check-tool.php
+++ b/HealthCheck/Tools/class-health-check-tool.php
@@ -21,7 +21,10 @@ abstract class Health_Check_Tool {
 		add_filter( 'health_check_tools_tab', array( $this, 'tab_setup' ) );
 	}
 
+	abstract public function set_description();
+
 	public function tab_setup( $tabs ) {
+		$this->set_description();
 		if ( ! isset( $this->label ) || empty( $this->label ) ) {
 			return $tabs;
 		}


### PR DESCRIPTION
## Short introduction
- This fixes a [WordPress 6.7 warning about loading translations too early](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/).

## Description of what the PR accomplishes
Admittedly, I cannot see a change in behavior, translations are loaded in the user language even without this PR. Still, I believe it is best practice to load the translations through the hook.

This error message is thrown before the PR:
```
#0 wp-includes/l10n.php(1386): _load_textdomain_just_in_time('health-check')
#1 wp-includes/l10n.php(194): get_translations_for_domain('health-check')
#2 wp-includes/l10n.php(306): translate('File integrity', 'health-check')
#3 wp-content/plugins/health-check/HealthCheck/Tools/class-health-check-files-integrity.php(20): __('File integrity', 'health-check')
#4 wp-content/plugins/health-check/HealthCheck/Tools/class-health-check-files-integrity.php(297): Health_Check_Files_Integrity->__construct()
#5 wp-content/plugins/health-check/health-check.php(72): require_once('wp-content/plugi...')
#6 wp-includes/class-wp-hook.php(324): HealthCheck\{closure}('')
#7 wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#8 wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#9 wp-settings.php(559): do_action('plugins_loaded')
#10 wp-config.php(232): require_once('wp-content/plugi...')
#11 wp-load.php(50): require_once('wp-content/plugi...')
#12 wp-blog-header.php(13): require_once('wp-content/plugi...')
#13 index.php(17): require('wp-content/plugi...')
```