### PR TITLE
Fix error thrown related to translations loaded too early

### DIFF
--- a/HealthCheck/Tools/class-health-check-beta-features.php
+++ b/HealthCheck/Tools/class-health-check-beta-features.php
@@ -17,12 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Health_Check_Beta_Features extends Health_Check_Tool {
 
 	public function __construct() {
-		$this->label       = __( 'Beta features', 'health-check' );
-		$this->description = __( 'The plugin may contain beta features, which you as the site owner can enable or disable as you wish.', 'health-check' );
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
 
 		parent::__construct();
 
 		add_action( 'admin_init', array( $this, 'toggle_beta_features' ) );
+	}
+
+	public function set_label_and_description() {
+		$this->label       = __( 'Beta features', 'health-check' );
+		$this->description = __( 'The plugin may contain beta features, which you as the site owner can enable or disable as you wish.', 'health-check' );
 	}
 
 	public function toggle_beta_features() {

--- a/HealthCheck/Tools/class-health-check-debug-log-viewer.php
+++ b/HealthCheck/Tools/class-health-check-debug-log-viewer.php
@@ -3,10 +3,14 @@
 class Health_Check_Debug_Log_Viewer extends Health_Check_Tool {
 
 	public function __construct() {
-		$this->label       = __( 'Debug logs', 'health-check' );
-		$this->description = __( 'The details below are gathered from your <code>debug.log</code> file, and is displayed because the <code>WP_DEBUG_LOG</code> constant has been set to allow logging of warnings and errors.', 'health-check' );
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
 
 		parent::__construct();
+	}
+
+	public function set_label_and_description() {
+		$this->label       = __( 'Debug logs', 'health-check' );
+		$this->description = __( 'The details below are gathered from your <code>debug.log</code> file, and is displayed because the <code>WP_DEBUG_LOG</code> constant has been set to allow logging of warnings and errors.', 'health-check' );
 	}
 
 	private function read_debug_log() {

--- a/HealthCheck/Tools/class-health-check-files-integrity.php
+++ b/HealthCheck/Tools/class-health-check-files-integrity.php
@@ -17,13 +17,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Health_Check_Files_Integrity extends Health_Check_Tool {
 
 	public function __construct() {
-		$this->label       = __( 'File integrity', 'health-check' );
-		$this->description = __( 'The File Integrity checks all the core files with the <code>checksums</code> provided by the WordPress API to see if they are intact. If there are changes you will be able to make a Diff between the files hosted on WordPress.org and your installation to see what has been changed.', 'health-check' );
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
 
 		add_action( 'wp_ajax_health-check-files-integrity-check', array( $this, 'run_files_integrity_check' ) );
 		add_action( 'wp_ajax_health-check-view-file-diff', array( $this, 'view_file_diff' ) );
 
 		parent::__construct();
+	}
+
+	public function set_label_and_description() {
+		$this->label       = __( 'File integrity', 'health-check' );
+		$this->description = __( 'The File Integrity checks all the core files with the <code>checksums</code> provided by the WordPress API to see if they are intact. If there are changes you will be able to make a Diff between the files hosted on WordPress.org and your installation to see what has been changed.', 'health-check' );
 	}
 
 	/**

--- a/HealthCheck/Tools/class-health-check-htaccess.php
+++ b/HealthCheck/Tools/class-health-check-htaccess.php
@@ -17,10 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Health_Check_Htaccess extends Health_Check_Tool {
 
 	public function __construct() {
-		$this->label       = __( '.htaccess Viewer', 'health-check' );
-		$this->description = __( 'The <code>.htaccess</code> file tells your server (if supported) how to handle links and file requests. This file usually requires direct server access to view, but if your system supports these files, you can verify its content here.', 'health-check' );
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
 
 		parent::__construct();
+	}
+
+	public function set_label_and_description() {
+		$this->label       = __( '.htaccess Viewer', 'health-check' );
+		$this->description = __( 'The <code>.htaccess</code> file tells your server (if supported) how to handle links and file requests. This file usually requires direct server access to view, but if your system supports these files, you can verify its content here.', 'health-check' );
 	}
 
 	public function tab_content() {

--- a/HealthCheck/Tools/class-health-check-mail-check.php
+++ b/HealthCheck/Tools/class-health-check-mail-check.php
@@ -19,12 +19,16 @@ class Health_Check_Mail_Check extends Health_Check_Tool {
 	private $mail_error = null;
 
 	public function __construct() {
-		$this->label       = __( 'Mail Check', 'health-check' );
-		$this->description = __( 'The Mail Check will invoke the <code>wp_mail()</code> function and check if it succeeds. We will use the E-mail address you have set up, but you can change it below if you like.', 'health-check' );
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
 
 		add_action( 'wp_ajax_health-check-mail-check', array( $this, 'run_mail_check' ) );
 
 		parent::__construct();
+	}
+
+	public function set_label_and_description() {
+		$this->label       = __( 'Mail Check', 'health-check' );
+		$this->description = __( 'The Mail Check will invoke the <code>wp_mail()</code> function and check if it succeeds. We will use the E-mail address you have set up, but you can change it below if you like.', 'health-check' );
 	}
 
 	/**

--- a/HealthCheck/Tools/class-health-check-phpinfo.php
+++ b/HealthCheck/Tools/class-health-check-phpinfo.php
@@ -16,6 +16,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Health_Check_Phpinfo extends Health_Check_Tool {
 
 	public function __construct() {
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
+
+		add_action( 'site_health_tab_content', array( $this, 'add_site_health_tab_content' ) );
+
+		parent::__construct();
+	}
+
+	public function set_label_and_description() {
 		$this->label = __( 'PHP Info', 'health-check' );
 
 		if ( ! function_exists( 'phpinfo' ) ) {
@@ -23,10 +31,6 @@ class Health_Check_Phpinfo extends Health_Check_Tool {
 		} else {
 			$this->description = __( 'Some scenarios require you to look up more detailed server configurations than what is normally required. The PHP Info page allows you to view all available configuration options for your PHP setup. Please be advised that WordPress does not guarantee that any information shown on that page may not be considered sensitive.', 'health-check' );
 		}
-
-		add_action( 'site_health_tab_content', array( $this, 'add_site_health_tab_content' ) );
-
-		parent::__construct();
 	}
 
 	/**

--- a/HealthCheck/Tools/class-health-check-plugin-compatibility.php
+++ b/HealthCheck/Tools/class-health-check-plugin-compatibility.php
@@ -3,16 +3,20 @@
 class Health_Check_Plugin_Compatibility extends Health_Check_Tool {
 
 	public function __construct() {
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
+
+		add_action( 'rest_api_init', array( $this, 'register_plugin_compat_rest_route' ) );
+
+		parent::__construct();
+	}
+
+	public function set_label_and_description() {
 		$this->label       = __( 'Plugin compatibility', 'health-check' );
 		$this->description = sprintf(
 			'%s<br>%s',
 			__( 'Attempt to identify the compatibility of your plugins before upgrading PHP, note that a compatibility check may not always be accurate, and you may want to contact the plugin author to confirm that things will continue working.', 'health-check' ),
 			__( 'The compatibility check will need to send requests to the <a href="https://wptide.org">WPTide</a> project to fetch the test results for each of your plugins.', 'health-check' )
 		);
-
-		add_action( 'rest_api_init', array( $this, 'register_plugin_compat_rest_route' ) );
-
-		parent::__construct();
 	}
 
 	public function register_plugin_compat_rest_route() {

--- a/HealthCheck/Tools/class-health-check-robotstxt.php
+++ b/HealthCheck/Tools/class-health-check-robotstxt.php
@@ -17,10 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Health_Check_Robotstxt extends Health_Check_Tool {
 
 	public function __construct() {
-		$this->label       = __( 'robots.txt Viewer', 'health-check' );
-		$this->description = __( 'The <code>robots.txt</code> file tells search engines which directories are allowed to be crawled and which not. WordPress generates a virtual file if there is no physical file. If there is a non-virtual file, the content will be displayed here.', 'health-check' );
+		add_action( 'admin_init', array( $this, 'set_label_and_description' ) );
 
 		parent::__construct();
+	}
+
+	public function set_label_and_description() {
+		$this->label       = __( 'robots.txt Viewer', 'health-check' );
+		$this->description = __( 'The <code>robots.txt</code> file tells search engines which directories are allowed to be crawled and which not. WordPress generates a virtual file if there is no physical file. If there is a non-virtual file, the content will be displayed here.', 'health-check' );
 	}
 
 	public function tab_content() {


### PR DESCRIPTION
Resolves #477 

## Short introduction
- Fixes the error being thrown when `WP_DEBUG` is enabled.
> Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the health-check domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 6.7.0.) in .../wp-includes/functions.php on line 6114

## Screenshots

#### Before Patch
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/a02c812e-960b-4a37-90f7-e0513e897899" />

#### After Patch
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/71215606-0c2b-436b-978d-3405b824eff3" />

No more error and the translations still load.
