### PR TITLE
Update health-check-troubleshooting-mode.php

### DIFF
--- a/mu-plugin/health-check-troubleshooting-mode.php
+++ b/mu-plugin/health-check-troubleshooting-mode.php
@@ -36,6 +36,7 @@ class Health_Check_Troubleshooting_MU {
 	);
 
 	private $default_themes = array(
+		'twentytwentyfive'
 		'twentytwentyfour',
 		'twentytwentythree',
 		'twentytwentytwo',


### PR DESCRIPTION
Hi there, first PR for me, I hope it helps! :)

## Short introduction
When using Troubleshooting Mode with WordPress 6.8.3, I somehow see a notice prompting me to install a default theme, even if Twenty Twenty-Five is already installed.

## Suggested fix
I added `'twentytwentyfive'` to the `$default_themes` array in `mu-plugin/health-check-troubleshooting-mode.php` as the first entry (since it's the most recent default theme).

## How to test this fix
- Install WordPress 6.7+ with Twenty Twenty-Five
- Activate Troubleshooting Mode
- Verify no warning notice appears about missing default themes
- Confirm that Twenty Twenty-Five is detected when using `has_default_theme()` method