### PR TITLE
fix: defer tool class loading to init hook

### DIFF
--- a/health-check.php
+++ b/health-check.php
@@ -67,6 +67,18 @@ add_action(
 		require_once( dirname( __FILE__ ) . '/HealthCheck/class-health-check-screenshots.php' );
 		require_once( dirname( __FILE__ ) . '/HealthCheck/class-health-check-troubleshoot.php' );
 
+		// Initialize our plugin.
+		new Health_Check();
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			require_once( dirname( __FILE__ ) . '/HealthCheck/class-cli.php' );
+		}
+	}
+);
+
+add_action(
+	'init',
+	function() {
 		// Tools section.
 		require_once( dirname( __FILE__ ) . '/HealthCheck/Tools/class-health-check-tool.php' );
 		require_once( dirname( __FILE__ ) . '/HealthCheck/Tools/class-health-check-files-integrity.php' );
@@ -77,12 +89,6 @@ add_action(
 		require_once( dirname( __FILE__ ) . '/HealthCheck/Tools/class-health-check-htaccess.php' );
 		require_once( dirname( __FILE__ ) . '/HealthCheck/Tools/class-health-check-robotstxt.php' );
 		require_once( dirname( __FILE__ ) . '/HealthCheck/Tools/class-health-check-beta-features.php' );
-
-		// Initialize our plugin.
-		new Health_Check();
-
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			require_once( dirname( __FILE__ ) . '/HealthCheck/class-cli.php' );
-		}
-	}
+	},
+	11
 );


### PR DESCRIPTION
## Short introduction
- Related to #513 (and the earlier #477 translation timing reports).
- Defers Health Check tool class loading from `plugins_loaded` to `init`.

## Description of what the PR accomplishes
Tool classes are required and instantiated during `plugins_loaded`, which triggers
`_load_textdomain_just_in_time` "doing it wrong" notices on WordPress 6.7+ when
translation functions run too early.

This moves all tool `require_once` calls into an `init` callback (priority 11)
so tool instantiation happens after WordPress is fully bootstrapped. Core plugin
classes continue to load on `plugins_loaded` as before.

Note: the `load_i18n()` deferral mentioned in #513 is no longer applicable on
current trunk — that method was removed when #477 was addressed. Tool loading
timing is the remaining piece.

## Screenshots

**Before fix** — notice on Plugins page (official 1.7.1, WP 7.0.2):

<img width="1921" height="892" alt="Plugins page showing _load_textdomain_just_in_time notice before fix" src="https://github.com/user-attachments/assets/0b506ce6-0456-4aae-9a73-fe10807a45d8" />

**After fix** — same page with patched `health-check.php`:

<img width="1921" height="892" alt="Plugins page with no notice after fix" src="https://github.com/user-attachments/assets/63e1b8a7-a904-49f1-92d7-742726c57b8e" />

## Test plan
- [x] Reproduced notice on official 1.7.1 with `WP_DEBUG` enabled
- [x] Notice resolved after applying patch
- [x] Site Health → Tools tab renders correctly
- [ ] File integrity, mail check, and other tool AJAX actions verified by maintainer