### PR TITLE
Troubleshooting Mode: Validate theme and plugin slugs before they are used

### DIFF
--- a/HealthCheck/class-health-check.php
+++ b/HealthCheck/class-health-check.php
@@ -151,8 +151,18 @@ class Health_Check {
 			return;
 		}
 
+		$plugin_slug = sanitize_text_field( wp_unslash( $_GET['health-check-troubleshoot-plugin'] ) );
+
 		// Don't enable troubleshooting for an individual plugin if the nonce is missing or invalid.
-		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'health-check-troubleshoot-plugin-' . $_GET['health-check-troubleshoot-plugin'] ) ) {
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'health-check-troubleshoot-plugin-' . $plugin_slug ) ) {
+			return;
+		}
+
+		/*
+		 * Only slugs belonging to an installed plugin are accepted, this also discards any
+		 * slug attempting to reference a location outside of the plugins directory.
+		 */
+		if ( 0 !== validate_file( $plugin_slug ) || ! in_array( $plugin_slug, $this->get_installed_plugin_slugs(), true ) ) {
 			return;
 		}
 
@@ -187,11 +197,45 @@ class Health_Check {
 
 		Health_Check_Troubleshoot::initiate_troubleshooting_mode(
 			array(
-				$_GET['health-check-troubleshoot-plugin'] => $_GET['health-check-troubleshoot-plugin'],
+				$plugin_slug => $plugin_slug,
 			)
 		);
 
 		wp_redirect( admin_url( 'plugins.php' ) );
+	}
+
+	/**
+	 * Get the slugs of every installed plugin.
+	 *
+	 * @uses function_exists()
+	 * @uses trailingslashit()
+	 * @uses get_plugins()
+	 * @uses array_keys()
+	 * @uses stristr()
+	 * @uses explode()
+	 *
+	 * @return array Array of plugin slugs.
+	 */
+	private function get_installed_plugin_slugs() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once trailingslashit( ABSPATH ) . 'wp-admin/includes/plugin.php';
+		}
+
+		$slugs = array();
+
+		foreach ( array_keys( get_plugins() ) as $plugin_file ) {
+			// Plugins living in the plugins directory root are identified by their filename.
+			if ( ! stristr( $plugin_file, '/' ) ) {
+				$slugs[] = $plugin_file;
+				continue;
+			}
+
+			$plugin_parts = explode( '/', $plugin_file );
+
+			$slugs[] = $plugin_parts[0];
+		}
+
+		return $slugs;
 	}
 
 	/**

--- a/mu-plugin/health-check-troubleshooting-mode.php
+++ b/mu-plugin/health-check-troubleshooting-mode.php
@@ -446,7 +446,10 @@ class Health_Check_Troubleshooting_MU {
 		$slugs = array();
 
 		foreach ( $this->active_plugins as $single_plugin ) {
-			// Split up the plugin path, [0] is the slug and [1] holds the primary plugin file.
+			/*
+			 * The slug is the first segment of the plugin path. Plugins living in the
+			 * plugins directory root have no other segment, and are identified by their filename.
+			 */
 			$plugin_parts = explode( '/', $single_plugin );
 
 			$slugs[] = $plugin_parts[0];
@@ -517,7 +520,10 @@ class Health_Check_Troubleshooting_MU {
 
 		// If we've received a comma-separated list of allowed plugins, we'll add them to the array of allowed plugins.
 		if ( isset( $_GET['health-check-allowed-plugins'] ) ) {
-			$allowed_plugins = explode( ',', sanitize_text_field( wp_unslash( $_GET['health-check-allowed-plugins'] ) ) );
+			$allowed_plugins = array_map(
+				'trim',
+				explode( ',', sanitize_text_field( wp_unslash( $_GET['health-check-allowed-plugins'] ) ) )
+			);
 
 			// Discard any entry which does not hold a plausible plugin slug.
 			$this->allowed_plugins = array_values(

--- a/mu-plugin/health-check-troubleshooting-mode.php
+++ b/mu-plugin/health-check-troubleshooting-mode.php
@@ -2,7 +2,7 @@
 /*
 	Plugin Name: Health Check Troubleshooting Mode
 	Description: Conditionally disabled themes or plugins on your site for a given session, used to rule out conflicts during troubleshooting.
-	Version: 1.9.2
+	Version: 1.9.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Set the MU plugin version.
-define( 'HEALTH_CHECK_TROUBLESHOOTING_MODE_PLUGIN_VERSION', '1.9.3' );
+define( 'HEALTH_CHECK_TROUBLESHOOTING_MODE_PLUGIN_VERSION', '1.9.4' );
 
 class Health_Check_Troubleshooting_MU {
 	private $disable_hash    = null;
@@ -134,7 +134,13 @@ class Health_Check_Troubleshooting_MU {
 		$this->allowed_plugins = get_option( 'health-check-allowed-plugins', array() );
 		$this->default_theme   = ( 'yes' === get_option( 'health-check-default-theme', 'yes' ) ? true : false );
 		$this->active_plugins  = $this->get_unfiltered_plugin_list();
-		$this->current_theme   = get_option( 'health-check-current-theme', false );
+
+		/*
+		 * Discard any stored theme slug which no longer resolves to an actual theme, this
+		 * also covers entries which may have been tampered with to point elsewhere.
+		 */
+		$current_theme       = get_option( 'health-check-current-theme', false );
+		$this->current_theme = ( $this->theme_exists( $current_theme ) ? $current_theme : false );
 	}
 
 	/**
@@ -429,6 +435,47 @@ class Health_Check_Troubleshooting_MU {
 	}
 
 	/**
+	 * Get the slugs of the plugins which are active outside of Troubleshooting Mode.
+	 *
+	 * Used to validate that a user supplied plugin slug belongs to a plugin which
+	 * may actually be toggled during a Troubleshooting session.
+	 *
+	 * @return array Array of plugin slugs.
+	 */
+	private function get_active_plugin_slugs() {
+		$slugs = array();
+
+		foreach ( $this->active_plugins as $single_plugin ) {
+			// Split up the plugin path, [0] is the slug and [1] holds the primary plugin file.
+			$plugin_parts = explode( '/', $single_plugin );
+
+			$slugs[] = $plugin_parts[0];
+		}
+
+		return $slugs;
+	}
+
+	/**
+	 * Validate a user supplied plugin slug.
+	 *
+	 * @param string $plugin_slug The plugin slug to validate.
+	 *
+	 * @return bool
+	 */
+	private function is_valid_plugin_slug( $plugin_slug ) {
+		if ( ! is_string( $plugin_slug ) || '' === $plugin_slug ) {
+			return false;
+		}
+
+		// Discard any slug attempting to traverse outside of the plugins directory.
+		if ( 0 !== validate_file( $plugin_slug ) ) {
+			return false;
+		}
+
+		return in_array( $plugin_slug, $this->get_active_plugin_slugs(), true );
+	}
+
+	/**
 	 * Check if the user is currently in Troubleshooting Mode or not.
 	 *
 	 * @return bool
@@ -470,7 +517,17 @@ class Health_Check_Troubleshooting_MU {
 
 		// If we've received a comma-separated list of allowed plugins, we'll add them to the array of allowed plugins.
 		if ( isset( $_GET['health-check-allowed-plugins'] ) ) {
-			$this->allowed_plugins = explode( ',', $_GET['health-check-allowed-plugins'] );
+			$allowed_plugins = explode( ',', sanitize_text_field( wp_unslash( $_GET['health-check-allowed-plugins'] ) ) );
+
+			// Discard any entry which does not hold a plausible plugin slug.
+			$this->allowed_plugins = array_values(
+				array_filter(
+					$allowed_plugins,
+					function ( $plugin_slug ) {
+						return ( '' !== $plugin_slug && 0 === validate_file( $plugin_slug ) );
+					}
+				)
+			);
 		}
 
 		foreach ( $plugins as $plugin_no => $plugin_path ) {
@@ -510,11 +567,28 @@ class Health_Check_Troubleshooting_MU {
 	/**
 	 * Check if a theme exists by looking for the slug.
 	 *
+	 * The slug is validated before it is used as part of a path, to make sure it can not
+	 * be used to reference a location outside of the themes directory.
+	 *
 	 * @param string $theme_slug
 	 *
 	 * @return bool
 	 */
 	public function theme_exists( $theme_slug ) {
+		if ( ! is_string( $theme_slug ) || '' === $theme_slug ) {
+			return false;
+		}
+
+		// A theme slug is a directory name, and may never hold a path separator.
+		if ( false !== strpbrk( $theme_slug, '/\\' ) ) {
+			return false;
+		}
+
+		// Discard any slug attempting to traverse outside of the themes directory.
+		if ( 0 !== validate_file( $theme_slug ) ) {
+			return false;
+		}
+
 		return is_dir( WP_CONTENT_DIR . '/themes/' . $theme_slug );
 	}
 
@@ -550,6 +624,11 @@ class Health_Check_Troubleshooting_MU {
 			return $default;
 		}
 
+		// Never hand out a slug which does not belong to an actual theme.
+		if ( ! $this->theme_exists( $this->current_theme ) ) {
+			$this->current_theme = false;
+		}
+
 		if ( empty( $this->current_theme_details ) ) {
 			$this->self_fetching_theme   = true;
 			$this->current_theme_details = wp_get_theme( $this->current_theme );
@@ -583,6 +662,11 @@ class Health_Check_Troubleshooting_MU {
 
 		if ( ! $this->override_theme() ) {
 			return $default;
+		}
+
+		// Never hand out a slug which does not belong to an actual theme.
+		if ( ! $this->theme_exists( $this->current_theme ) ) {
+			$this->current_theme = false;
 		}
 
 		if ( empty( $this->current_theme_details ) ) {
@@ -765,15 +849,17 @@ class Health_Check_Troubleshooting_MU {
 
 		// Enable an individual plugin.
 		if ( isset( $_GET['health-check-troubleshoot-enable-plugin'] ) ) {
+			$enable_plugin = sanitize_text_field( wp_unslash( $_GET['health-check-troubleshoot-enable-plugin'] ) );
+
 			// Validate the cache or return early.
-			if ( ! $this->validate_action_nonce( 'health-check-troubleshoot-enable-plugin', array( $_GET['health-check-troubleshoot-enable-plugin'] ) ) ) {
+			if ( ! $this->validate_action_nonce( 'health-check-troubleshoot-enable-plugin', array( $enable_plugin ) ) ) {
 				$this->show_nonce_validator   = true;
 				$this->nonce_validator_fields = array(
 					'_wpnonce' => $this->prepare_action_nonce(
 						'health-check-troubleshoot-enable-plugin',
-						array( $_GET['health-check-troubleshoot-enable-plugin'] )
+						array( $enable_plugin )
 					),
-					'health-check-troubleshoot-enable-plugin' => implode( ',', array( $_GET['health-check-troubleshoot-enable-plugin'] ) ),
+					'health-check-troubleshoot-enable-plugin' => implode( ',', array( $enable_plugin ) ),
 				);
 
 				$this->nonce_validator_details = sprintf(
@@ -783,7 +869,7 @@ class Health_Check_Troubleshooting_MU {
 						__( 'You were attempting to <strong>enable</strong> the %s plugin while troubleshooting.', 'health-check' ),
 						sprintf(
 							'<strong>%s</strong>',
-							$_GET['health-check-troubleshoot-enable-plugin']
+							esc_html( $enable_plugin )
 						)
 					)
 				);
@@ -791,9 +877,20 @@ class Health_Check_Troubleshooting_MU {
 				return;
 			}
 
+			// Only plugins which are actually installed and active may be toggled.
+			if ( ! $this->is_valid_plugin_slug( $enable_plugin ) ) {
+				$this->add_dashboard_notice(
+					esc_html__( 'The plugin you attempted to enable could not be found, so no changes were made.', 'health-check' ),
+					'warning'
+				);
+
+				wp_redirect( remove_query_arg( $this->available_query_args ) );
+				die();
+			}
+
 			$old_allowed_plugins = $this->allowed_plugins;
 
-			$this->allowed_plugins[ $_GET['health-check-troubleshoot-enable-plugin'] ] = $_GET['health-check-troubleshoot-enable-plugin'];
+			$this->allowed_plugins[ $enable_plugin ] = $enable_plugin;
 
 			update_option( 'health-check-allowed-plugins', $this->allowed_plugins );
 
@@ -802,7 +899,7 @@ class Health_Check_Troubleshooting_MU {
 					sprintf(
 						// translators: %s: The plugin slug.
 						'The %s plugin was forcefully enabled.',
-						$_GET['health-check-troubleshoot-enable-plugin']
+						esc_html( $enable_plugin )
 					),
 					'info'
 				);
@@ -815,15 +912,15 @@ class Health_Check_Troubleshooting_MU {
 				$notice = sprintf(
 					// Translators: %1$s: The link-button markup to force enable the plugin. %2$s: The force-enable link markup.
 					__( 'When enabling the plugin, %1$s, a site failure occurred. Because of this the change was automatically reverted. %2$s', 'health-check' ),
-					$_GET['health-check-troubleshoot-enable-plugin'],
+					esc_html( $enable_plugin ),
 					sprintf(
 						'<a href="%s" aria-label="%s">%s</a>',
 						esc_url(
 							add_query_arg(
 								array(
-									'health-check-troubleshoot-enable-plugin' => $_GET['health-check-troubleshoot-enable-plugin'],
+									'health-check-troubleshoot-enable-plugin' => $enable_plugin,
 									'health-check-plugin-force-enable' => 'true',
-									'_wpnonce' => $this->prepare_action_nonce( 'health-check-troubleshoot-enable-plugin', array( $_GET['health-check-troubleshoot-enable-plugin'] ) ),
+									'_wpnonce' => $this->prepare_action_nonce( 'health-check-troubleshoot-enable-plugin', array( $enable_plugin ) ),
 								),
 								$this->get_clean_url()
 							)
@@ -832,7 +929,7 @@ class Health_Check_Troubleshooting_MU {
 							sprintf(
 								// translators: %s: Plugin name.
 								__( 'Force-enable the plugin, %s, even though the loopback checks failed.', 'health-check' ),
-								$_GET['health-check-troubleshoot-enable-plugin']
+								$enable_plugin
 							)
 						),
 						__( 'Enable anyway', 'health-check' )
@@ -851,15 +948,17 @@ class Health_Check_Troubleshooting_MU {
 
 		// Disable an individual plugin.
 		if ( isset( $_GET['health-check-troubleshoot-disable-plugin'] ) ) {
+			$disable_plugin = sanitize_text_field( wp_unslash( $_GET['health-check-troubleshoot-disable-plugin'] ) );
+
 			// Validate the cache or return early.
-			if ( ! $this->validate_action_nonce( 'health-check-troubleshoot-disable-plugin', array( $_GET['health-check-troubleshoot-disable-plugin'] ) ) ) {
+			if ( ! $this->validate_action_nonce( 'health-check-troubleshoot-disable-plugin', array( $disable_plugin ) ) ) {
 				$this->show_nonce_validator   = true;
 				$this->nonce_validator_fields = array(
 					'_wpnonce' => $this->prepare_action_nonce(
 						'health-check-troubleshoot-disable-plugin',
-						array( $_GET['health-check-troubleshoot-disable-plugin'] )
+						array( $disable_plugin )
 					),
-					'health-check-troubleshoot-disable-plugin' => implode( ',', array( $_GET['health-check-troubleshoot-disable-plugin'] ) ),
+					'health-check-troubleshoot-disable-plugin' => implode( ',', array( $disable_plugin ) ),
 				);
 
 				$this->nonce_validator_details = sprintf(
@@ -869,16 +968,28 @@ class Health_Check_Troubleshooting_MU {
 						__( 'You were attempting to <strong>disable</strong> the %s plugin while troubleshooting.', 'health-check' ),
 						sprintf(
 							'<strong>%s</strong>',
-							$_GET['health-check-troubleshoot-disable-plugin']
+							esc_html( $disable_plugin )
 						)
 					)
 				);
 
 				return;
 			}
+
+			// Only plugins which are actually installed and active may be toggled.
+			if ( ! $this->is_valid_plugin_slug( $disable_plugin ) ) {
+				$this->add_dashboard_notice(
+					esc_html__( 'The plugin you attempted to disable could not be found, so no changes were made.', 'health-check' ),
+					'warning'
+				);
+
+				wp_redirect( remove_query_arg( $this->available_query_args ) );
+				die();
+			}
+
 			$old_allowed_plugins = $this->allowed_plugins;
 
-			unset( $this->allowed_plugins[ $_GET['health-check-troubleshoot-disable-plugin'] ] );
+			unset( $this->allowed_plugins[ $disable_plugin ] );
 
 			update_option( 'health-check-allowed-plugins', $this->allowed_plugins );
 
@@ -887,7 +998,7 @@ class Health_Check_Troubleshooting_MU {
 					sprintf(
 						// translators: %s: The plugin slug.
 						'The %s plugin was forcefully disabled.',
-						$_GET['health-check-troubleshoot-disable-plugin']
+						esc_html( $disable_plugin )
 					),
 					'info'
 				);
@@ -900,15 +1011,15 @@ class Health_Check_Troubleshooting_MU {
 				$notice = sprintf(
 					// Translators: %1$s: The plugin slug that was disabled. %2$s: The force-disable link markup.
 					__( 'When disabling the plugin, %1$s, a site failure occurred. Because of this the change was automatically reverted. %2$s', 'health-check' ),
-					$_GET['health-check-troubleshoot-disable-plugin'],
+					esc_html( $disable_plugin ),
 					sprintf(
 						'<a href="%1$s" aria-label="%2$s">%3$s</a>',
 						esc_url(
 							add_query_arg(
 								array(
-									'health-check-troubleshoot-disable-plugin' => $_GET['health-check-troubleshoot-disable-plugin'],
+									'health-check-troubleshoot-disable-plugin' => $disable_plugin,
 									'health-check-plugin-force-disable' => 'true',
-									'_wpnonce' => $this->prepare_action_nonce( 'health-check-troubleshoot-disable-plugin', array( $_GET['health-check-troubleshoot-disable-plugin'] ) ),
+									'_wpnonce' => $this->prepare_action_nonce( 'health-check-troubleshoot-disable-plugin', array( $disable_plugin ) ),
 								),
 								$this->get_clean_url()
 							)
@@ -917,7 +1028,7 @@ class Health_Check_Troubleshooting_MU {
 							sprintf(
 								// translators: %s: Plugin name.
 								__( 'Force-disable the plugin, %s, even though the loopback checks failed.', 'health-check' ),
-								$_GET['health-check-troubleshoot-disable-plugin']
+								$disable_plugin
 							)
 						),
 						__( 'Disable anyway', 'health-check' )
@@ -936,15 +1047,17 @@ class Health_Check_Troubleshooting_MU {
 
 		// Change the active theme for this session.
 		if ( isset( $_GET['health-check-change-active-theme'] ) ) {
+			$requested_theme = sanitize_text_field( wp_unslash( $_GET['health-check-change-active-theme'] ) );
+
 			// Validate the cache or return early.
-			if ( ! $this->validate_action_nonce( 'health-check-change-active-theme', array( $_GET['health-check-change-active-theme'] ) ) ) {
+			if ( ! $this->validate_action_nonce( 'health-check-change-active-theme', array( $requested_theme ) ) ) {
 				$this->show_nonce_validator   = true;
 				$this->nonce_validator_fields = array(
 					'_wpnonce'                         => $this->prepare_action_nonce(
 						'health-check-change-active-theme',
-						array( $_GET['health-check-change-active-theme'] )
+						array( $requested_theme )
 					),
-					'health-check-change-active-theme' => implode( ',', array( $_GET['health-check-change-active-theme'] ) ),
+					'health-check-change-active-theme' => implode( ',', array( $requested_theme ) ),
 				);
 
 				$this->nonce_validator_details = sprintf(
@@ -954,7 +1067,7 @@ class Health_Check_Troubleshooting_MU {
 						__( 'You were attempting to <strong>change the active theme</strong> to %s while troubleshooting.', 'health-check' ),
 						sprintf(
 							'<strong>%s</strong>',
-							$_GET['health-check-change-active-theme']
+							esc_html( $requested_theme )
 						)
 					)
 				);
@@ -962,16 +1075,30 @@ class Health_Check_Troubleshooting_MU {
 				return;
 			}
 
+			/*
+			 * Only themes which actually exist may be activated, this also discards any attempt
+			 * at pointing the active theme at a location outside of the themes directory.
+			 */
+			if ( ! $this->theme_exists( $requested_theme ) ) {
+				$this->add_dashboard_notice(
+					esc_html__( 'The theme you attempted to switch to could not be found, so the theme was left unchanged.', 'health-check' ),
+					'warning'
+				);
+
+				wp_redirect( remove_query_arg( $this->available_query_args ) );
+				die();
+			}
+
 			$old_theme = get_option( 'health-check-current-theme' );
 
-			update_option( 'health-check-current-theme', $_GET['health-check-change-active-theme'] );
+			update_option( 'health-check-current-theme', $requested_theme );
 
 			if ( isset( $_GET['health-check-theme-force-switch'] ) ) {
 				$this->add_dashboard_notice(
 					sprintf(
 						// translators: %s: The theme slug.
 						'The theme was forcefully switched to %s.',
-						$_GET['health-check-change-active-theme']
+						esc_html( $requested_theme )
 					),
 					'info'
 				);
@@ -983,15 +1110,15 @@ class Health_Check_Troubleshooting_MU {
 				$notice = sprintf(
 					// Translators: %1$s: The theme slug that was switched to.. %2$s: The force-enable link markup.
 					__( 'When switching the active theme to %1$s, a site failure occurred. Because of this we reverted the theme to the one you used previously. %2$s', 'health-check' ),
-					$_GET['health-check-change-active-theme'],
+					esc_html( $requested_theme ),
 					sprintf(
 						'<a href="%s" aria-label="%s">%s</a>',
 						esc_url(
 							add_query_arg(
 								array(
-									'health-check-change-active-theme' => $_GET['health-check-change-active-theme'],
+									'health-check-change-active-theme' => $requested_theme,
 									'health-check-theme-force-switch' => 'true',
-									'_wpnonce' => $this->prepare_action_nonce( 'health-check-change-active-theme', array( $_GET['health-check-change-active-theme'] ) ),
+									'_wpnonce' => $this->prepare_action_nonce( 'health-check-change-active-theme', array( $requested_theme ) ),
 								),
 								$this->get_clean_url()
 							)
@@ -1000,7 +1127,7 @@ class Health_Check_Troubleshooting_MU {
 							sprintf(
 								// translators: %s: Plugin name.
 								__( 'Force-switch to the %s theme, even though the loopback checks failed.', 'health-check' ),
-								$_GET['health-check-change-active-theme']
+								$requested_theme
 							)
 						),
 						__( 'Switch anyway', 'health-check' )


### PR DESCRIPTION
Fixes the path traversal reported as CVE-2025-64253, which is still unpatched in 1.7.1 and is what #502 is asking about.

## The problem

Troubleshooting Mode lets you switch the active theme for your own session. The requested slug is stored verbatim and later returned from the `pre_option_stylesheet` and `pre_option_template` filters, without ever being checked against the themes that exist:

1. `mu-plugin/health-check-troubleshooting-mode.php:967` — `$_GET['health-check-change-active-theme']` goes straight into the `health-check-current-theme` option.
2. `:137` — `load_options()` reads it back.
3. `:544-607` — both theme filters return it unchanged.
4. `:517-519` — `theme_exists()` only calls `is_dir()`, so `../` is never rejected.

Because the value becomes the return of `pre_option_stylesheet`, WordPress resolves the theme root as `get_theme_root() . '/' . <value>`, and a slug such as `../plugins/hello-dolly` points the active theme outside of `wp-content/themes`.

Worth noting: the missing nonce is not a barrier. Requesting the URL without one renders the plugin's own "Security check" confirmation dialog, and that dialog hands back a valid nonce generated from the unvalidated slug.

## The fix

`theme_exists()` becomes the single validation gate, and is now consulted from both directions — when a slug is received, and again before a stored slug is used, so that an option value tampered with on an older version is discarded rather than trusted:

```php
public function theme_exists( $theme_slug ) {
	if ( ! is_string( $theme_slug ) || '' === $theme_slug ) {
		return false;
	}

	// A theme slug is a directory name, and may never hold a path separator.
	if ( false !== strpbrk( $theme_slug, '/\\' ) ) {
		return false;
	}

	// Discard any slug attempting to traverse outside of the themes directory.
	if ( 0 !== validate_file( $theme_slug ) ) {
		return false;
	}

	return is_dir( WP_CONTENT_DIR . '/themes/' . $theme_slug );
}
```

`validate_file()` alone would still allow a value whose only `../` sits at the end, such as `sometheme/../`. Since a theme slug is a plain directory name, path separators are rejected outright.

Along the way, and in the same spirit:

- the plugin slugs received through the individual enable/disable actions are validated against the plugins that are actually active, instead of storing whatever arrives;
- request values echoed back into dashboard notices are escaped;
- `HealthCheck/class-health-check.php` validates `health-check-troubleshoot-plugin` before it is handed to `initiate_troubleshooting_mode()`.

## One thing worth a second look

The MU plugin header said `Version: 1.9.2` while the constant said `1.9.3`. `Health_Check_Troubleshoot::maybe_update_must_use_plugin()` compares the **header** of the bundled file against the deployed copy in `wp-content/mu-plugins/`, so without bumping the header a fixed release would not replace the vulnerable MU plugin on sites that already have one. Both now read `1.9.4`.

## Verification

- `phpcs` reports no new violations (what remains — line endings, the MU plugin file name, the `$default` parameter names — is pre-existing).
- Behaviour was verified with a small harness that loads the MU plugin against stubbed WordPress functions, with `validate_file()` copied verbatim from core. Before the change, `theme_exists( '../plugins/…' )` returns `true` and the `stylesheet` filter hands back `../plugins/…`; after it, the filters fall back to the default theme and a real theme slug still passes through untouched.

Happy to adjust anything here — including splitting the plugin slug and escaping changes into a separate PR if you would rather keep this one focused on the traversal itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
